### PR TITLE
smart: add `+check-compiles` generator for contracts

### DIFF
--- a/gen/check-compiles.hoon
+++ b/gen/check-compiles.hoon
@@ -1,0 +1,19 @@
+::  check-compiles: tests the contract for compilation and returns the compiled contract
+::
+::::
+  ::
+:-  %say
+|=  $:  [now=@da eny=@uvJ [our=ship * *]]
+        [[name=@tas ~] ~]
+    ==
+=/  contract-name=@tas  (scot %tas name)  :: paranoia
+=/  pax=path   /(scot %p our)/zig/(scot %da now)/lib/zig/contracts/[contract-name]/hoon
+?:  !.^(? %cu pax)
+  tang+[leaf+"Error: contract '{<`path`(oust [0 3] `(list @tas)`pax)>}' does not exist." ~]
+=/  smart          .^(vase %ca /(scot %p our)/zig/(scot %da now)/lib/zig/sys/smart/hoon)
+=/  contract-src   .^(@t %cx pax)
+=/  contract
+  ~|  "contract {<contract-name>} failed to compile!"
+  (slap smart (ream contract-src))
+:-  %tang
+[leaf+"contract {<contract-name>} compiled succesfully" ~]


### PR DESCRIPTION
This mini-PR adds in a simple generator to solve the pain point of having to constantly comment/uncomment `::  /+  *zig-sys-smart`, as @hosted-fornet also pointed out.

The generator takes in a single `@tas`, which is the name of the contract in the appropriate directory (it searches in `/=zig=/lib/zig/sys/contracts/<name>/hoon`, and can be extended to an actual path if need be).

To use, first cd into the `%zig` desk, then use the following invocation:
```hoon
~nec:dojo> 
=dir /=zig
+check-compiles %multisig
```
or alternatively use the direct (slightly longer) syntax `+zig!check-compiles`.

Not sure if this is missing something since it doesn't go through the `deploy.hoon` means, but it worked thus far so ¯\\\_(ツ)_/¯.

Please try it out and let me know if it is useful or if there are any improvements that I can make. It's definitely not a final solution but could be used in the short term.