### PR TITLE
wallet: add %keys scry

### DIFF
--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -468,6 +468,8 @@
         |=  [town=@ud nonce=@ud]
         [(scot %ud town) (numb nonce)]
     ==
+      [%keys ~]
+    ``noun+!>(~(key by keys.state))
   ::
       [%account @ @ ~]
     ::  returns our account for the pubkey and town-id given

--- a/gen/wallet/basic-tx.hoon
+++ b/gen/wallet/basic-tx.hoon
@@ -1,10 +1,12 @@
 :-  %say
 |=  [[now=@da eny=@uvJ bek=beak] [town-id=@ud to=@ux amt=@ud ~] ~]
+=+  .^(keys=(set @ux) %gx /(scot %p p.bek)/wallet/(scot %da now)/keys/noun)
+?>  !=(~ keys)
 :-  %zig-wallet-poke
 :*  %submit
-    0x2.e3c1.d19b.fd3e.43aa.319c.b816.1c89.37fb.b246.3a65.f84d.8562.155d.6181.8113.c85b
-    `@ux`'fungible'
+    (head keys)
+    `@ux`'zigs-contract'
     town-id
     [1 10.000]
-    [%give `@ux`'zigs-metadata' to amt]
+    [%give `@ux`'zigs' to amt]
 ==


### PR DESCRIPTION
Adds a `%keys` case to `+on-peek` for retrieving the public keys associated with the wallet.

Fixes for `gen/basic-tx/hoon`. 
