### PR TITLE
sequencer/ziggurat: fix `read-rice`/`read-wheat` callsites

### DIFF
--- a/app/sequencer.hoon
+++ b/app/sequencer.hoon
@@ -270,10 +270,10 @@
     ``noun+!>(%.y)
   ::
       [%rice @ ~]
-    (read-rice path 0 (need town-id.state) p.town.state)
+    (read-rice +.path 0 (need town-id.state) p.town.state)
   ::
       [%wheat @ @ta ^]
-    (read-wheat path 0 (need town-id.state) p.town.state)
+    (read-wheat +.path 0 (need town-id.state) p.town.state)
   ::
       [%sizeof @ ~]
     ::  give size of item in town granary

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -590,10 +590,10 @@
   ::  scries for contracts
   ::
       [%rice @ ~]
-    (read-rice path height.state relay-town-id p.globe.state)
+    (read-rice +.path height.state relay-town-id p.globe.state)
   ::
       [%wheat @ @tas @ta ^]  :: grain id, %noun/%json, argument @ta, then any associated rice IDs
-    (read-wheat path height.state relay-town-id p.globe.state)
+    (read-wheat +.path height.state relay-town-id p.globe.state)
   ::
       [%sizeof @ ~]
     ::  give size of item in global granary


### PR DESCRIPTION
Fixes faulty arguments being passed into `+read-rice` and `read-wheat` respectively in the `on-peek` arms of both agents that use it. The util arms expect the path to be without the leading `%x` that is present in the path from the scry.