### PR TITLE
indexer: fix hash scry and scry latest state

### DIFF
--- a/app/indexer.hoon
+++ b/app/indexer.hoon
@@ -342,16 +342,21 @@
       =/  hash=@ux  (slav %ux i.t.t.path)
       =/  egg=(unit update:ui)
         (serve-update %egg hash)
-      =/  grain=(unit update:ui)
-        (serve-update %grain hash)
       =/  from=(unit update:ui)
         (serve-update %from hash)
+      =/  grain=(unit update:ui)
+        (serve-update %grain hash)
+      =/  holder=(unit update:ui)
+        (serve-update %holder hash)
+      =/  lord=(unit update:ui)
+        (serve-update %lord hash)
       =/  slot=(unit update:ui)
         (serve-update %block-hash hash)
       =/  to=(unit update:ui)
         (serve-update %to hash)
       =/  up=(unit update:ui)
-        (combine-updates ~[egg from to] ~[grain] slot)
+        %^  combine-updates  ~[egg from to]
+        ~[grain holder lord]  slot
       ?~  up  [~ ~]
       [~ ~ %indexer-update !>(`update:ui`u.up)]
     ::

--- a/app/indexer.hoon
+++ b/app/indexer.hoon
@@ -1118,7 +1118,7 @@
     ?>  =(1 (lent locations))
     =/  =location:ui  (snag 0 locations)
     ?.  ?=(town-location:ui location)  ~
-    ?~  chunk=(get-chunk location)                ~
+    ?~  chunk=(get-chunk location)     ~
     `[%chunk location u.chunk]
   ::
   ++  get-from-index
@@ -1154,6 +1154,15 @@
     ::
     ++  get-grain
       =|  grains=(map grain-id=id:smart [town-location:ui grain:smart])
+      =.  locations
+        %+  sort  ;;((list town-location:ui) locations)
+        |=  [p=town-location:ui q=town-location:ui]
+        ^-  ?
+        ?:  (lth epoch-num.p epoch-num.q)  %.y
+        ?.  =(epoch-num.p epoch-num.q)     %.n
+        ?:  (lth block-num.p block-num.q)  %.y
+        ?.  =(block-num.p block-num.q)     %.n
+        (gte town-id.p town-id.q)
       |-
       ?~  locations
         ?~  grains  ~


### PR DESCRIPTION
Two fixes, first to expand the scope of what `/hash` returns to be more in line with expectations, and second, to return the most recent `grain` with a given `id` upon a scry.

The `/hash` scry is supposed to return everything associated with the given hash. Therefore, it should also return the `/lord` and `/holder` results; 54c1910 makes this the case.

In changing the `update` types for `%grain` to `map` from `set` a change from returning the entire history of a `grain` to returning just a single element was also made (since older versions of the `grain` will share an `id`). The bug is that the most recent `grain` is not returned, but instead some past version since we store pointers to `grain`s in `jug`s, and the `set`s within `jug`s are not ordered by recency.

For indexing we have to make a choice between: the nice methods that `jug`s afford us (methods like `has:ju`, for example) and the ordering from 

In a subsequent PR, will add `/history` endpoints (e.g. `/grain/history`) to complement the current "most recent" scry paths.