### PR TITLE
mill: comment out zink printf causing compilation fail

### DIFF
--- a/lib/zig/mill.hoon
+++ b/lib/zig/mill.hoon
@@ -242,9 +242,6 @@
           ::  error in contract execution
           [~ budget %6]
         ::
-        ::~&  >>  [chick+(hole (unit chick) p.p.book) budget+bud.q.book]
-        ::  chick result
-        ::  ~&  >  p.-.res
         [`p.-.res budget %0]
         ::  this uses ZINK
         ::  

--- a/lib/zig/mill.hoon
+++ b/lib/zig/mill.hoon
@@ -241,7 +241,8 @@
         ?:  ?=(%| -.-.res)
           ::  error in contract execution
           [~ budget %6]
-        ~&  >>  [chick+(hole (unit chick) p.p.book) budget+bud.q.book]
+        ::
+        ::~&  >>  [chick+(hole (unit chick) p.p.book) budget+bud.q.book]
         ::  chick result
         ::  ~&  >  p.-.res
         [`p.-.res budget %0]


### PR DESCRIPTION
Without this, starting a testnet fails when running `|install our %zig`

cc @dr-frmr 