### PR TITLE
indexer: add `%grain-eggs` scry, subscribe, index

### DIFF
--- a/sur/indexer.hoon
+++ b/sur/indexer.hoon
@@ -8,6 +8,7 @@
       %egg
       %from
       %grain
+      %grain-eggs
       %holder
       %lord
       %slot


### PR DESCRIPTION
As per @willbach request: a scry/subscription to allow querying of all `egg`s/transactions a `rice` was involved in.