### PR TITLE
fungible: fix logic in `%mint` ensuring `mintable` is correctly set

### DIFF
--- a/lib/zig/contracts/fungible.hoon
+++ b/lib/zig/contracts/fungible.hoon
@@ -144,7 +144,7 @@
       =.  data.p.germ.tok
         %=  meta
           supply    new-total
-          mintable  ?:(=(u.cap.meta supply.meta) %.y %.n)
+          mintable  (lth supply.meta u.cap.meta)
         ==
       ::  for accounts which we know rice of, find in owns.cart
       ::  and alter. for others, generate id and add to c-call


### PR DESCRIPTION
I think new behavior is correct but would like a double check on it. I should note that I haven't done a thorough pass over the contract for correctness, but this still stood out to me.