### PR TITLE
wire pedersen jet to local arm

### DIFF
--- a/lib/zink/pedersen.hoon
+++ b/lib/zink/pedersen.hoon
@@ -1,5 +1,7 @@
+~%  %ped  ..part  ~
 |%
 ++  pedersen
+  ~%  %pedersen  +  ~
   |%
   ++  t
     ^-  domain:secp:crypto
@@ -58,9 +60,10 @@
           758.586.525.933.812.536.653.089.401.905.
           292.063.708.816.422
   ++  hash
-    |^
+    ~/  %phash
     |=  [a=@ b=@]
     ^-  @
+    |^
     =/  x  (has a)
     =/  y  (has b)
     +:(do-hash y x)


### PR DESCRIPTION
This goes with https://github.com/martyr-binbex/urbit/tree/mb/local-jet to wire up the pedersen jet to our local pedersen hash. It's temporary until the jet and hash are released in the main urbit repo.