### PR TITLE
sequencer: update `:sequencer|init` to work with new types

### DIFF
--- a/gen/sequencer/init.hoon
+++ b/gen/sequencer/init.hoon
@@ -14,35 +14,41 @@
 =/  zigs-3  (fry-rice:smart zigs-wheat-id:smart pubkey-3 town-id `@`'zigs')
 =/  beef-zigs-grain
   ^-  grain:smart
-  :*  zigs-1
+  :*  %&
+      `@`'zigs'
+      %account
+      [10.321.055.000.000.000.000 ~ `@ux`'zigs-metadata']
+      zigs-1
       zigs-wheat-id:smart
       pubkey-1
       town-id
-      [%& `@`'zigs' %account [10.321.055.000.000.000.000 ~ `@ux`'zigs-metadata']]
   ==
 =/  dead-zigs-grain
   ^-  grain:smart
-  :*  zigs-2
+  :*  %&
+      `@`'zigs'
+      %account
+      [50.000.000.000.000.000.000 ~ `@ux`'zigs-metadata']
+      zigs-2
       zigs-wheat-id:smart
       pubkey-2
       town-id
-      [%& `@`'zigs' %account [50.000.000.000.000.000.000 ~ `@ux`'zigs-metadata']]
   ==
 =/  cafe-zigs-grain
   ^-  grain:smart
-  :*  zigs-3
+  :*  %&
+      `@`'zigs'
+      %account
+      [50.000.000.000.000.000.000 ~ `@ux`'zigs-metadata']
+      zigs-3
       zigs-wheat-id:smart
       pubkey-3
       town-id
-      [%& `@`'zigs' %account [50.000.000.000.000.000.000 ~ `@ux`'zigs-metadata']]
   ==
-=/  zigs-metadata-grain
-  ^-  grain:smart
-  :*  `@ux`'zigs-metadata'
-      zigs-wheat-id:smart
-      zigs-wheat-id:smart
-      town-id
-      :^  %&  `@`'zigs'  %metadata 
+=/  zigs-metadata
+  ^-  rice:smart
+  :*  `@`'zigs'
+      %metadata
       :*  name='UQ| Tokens'
           symbol='ZIG'
           decimals=18
@@ -53,78 +59,95 @@
           deployer=0x0
           salt=`@`'zigs'
       ==
+      `@ux`'zigs-metadata'
+      zigs-wheat-id:smart
+      zigs-wheat-id:smart
+      town-id
   ==
-=/  zigs-wheat-grain
-  ^-  grain:smart
-  =/  =wheat:smart  ;;(wheat:smart (cue q.q.zigs-contract))
-  :*  zigs-wheat-id:smart  ::  id
+=/  zigs-wheat
+  ^-  wheat:smart
+  :*  `;;([bat=* pay=*] (cue q.q.zigs-contract))
+      interface=~  ::  TODO
+      types=~      ::  TODO
+      zigs-wheat-id:smart  ::  id
       zigs-wheat-id:smart  ::  lord
       zigs-wheat-id:smart  ::  holder
       town-id              ::  town-id
-      [%| wheat(owns (silt ~[zigs-1 zigs-2 zigs-3 `@ux`'zigs-metadata']))]
   ==
-::  publish.hoon contract
-=/  publish-grain
-  ^-  grain:smart
-  :*  0x1111.1111     ::  id
-      0x1111.1111     ::  lord
-      0x1111.1111     ::  holder
-      town-id         ::  town-id
-      [%| ;;(wheat:smart (cue q.q.publish-contract))]  ::  germ
-  ==
-::  ::  trivial.hoon contract
-=/  trivial-grain
-  ^-  grain:smart
-  :*  0xdada.dada     ::  id
-      0xdada.dada     ::  lord
-      0xdada.dada     ::  holder
-      town-id         ::  town-id
-      [%| ;;(wheat:smart (cue q.q.trivial-contract))]  ::  germ
-  ==
-::
-::  NFT stuff
-=/  nft-metadata-grain
-  ^-  grain:smart
-  :*  `@ux`'nft-metadata'
-      0xcafe.babe
-      0xcafe.babe
-      town-id
-      :+  %&  `@`'nftsalt'
-      :*  name='Monkey JPEGs'
-          symbol='BADART'
-          attributes=(silt ~['hair' 'eyes' 'mouth'])
-          supply=1
-          cap=~
-          mintable=%.n
-          minters=~
-          deployer=0x0
-          salt=`@`'nftsalt'
-  ==  ==
-=/  item-1
-  [1 (silt ~[['hair' 'red'] ['eyes' 'blue'] ['mouth' 'smile']]) 'a smiling monkey' 'ipfs://QmUbFVTm113tJEuJ4hZY2Hush4Urzx7PBVmQGjv1dXdSV9' %.y]
-=/  nft-acc-id  (fry-rice:smart 0xcafe.babe pubkey-1 town-id `@`'nftsalt')
-=/  nft-acc-grain
-  :*  nft-acc-id
-      0xcafe.babe
-      pubkey-1
-      town-id
-      [%& `@`'nftsalt' [`@ux`'nft-metadata' (malt ~[[1 item-1]]) ~ ~]]
-  ==
-=/  nft-wheat-grain
-  ^-  grain:smart
-  =/  =wheat:smart  ;;(wheat:smart (cue q.q.nft-contract))
-  :*  0xcafe.babe     ::  id
-      0xcafe.babe     ::  lord
-      0xcafe.babe     ::  holder
-      town-id         ::  town-id
-      [%| wheat(owns (silt ~[`@ux`'nft-metadata' nft-acc-id]))]  ::  germ
-  ==
+:: ::  publish.hoon contract
+:: =/  publish-grain
+::   ^-  grain:smart
+::   :*  %|
+::       `;;([bat=* pay=*] (cue q.q.publish-contract))
+::       interface=~  ::  TODO
+::       types=~      ::  TODO
+::       0x1111.1111     ::  id
+::       0x1111.1111     ::  lord
+::       0x1111.1111     ::  holder
+::       town-id         ::  town-id
+::   ==
+:: ::  trivial.hoon contract
+:: =/  trivial-grain
+::   ^-  grain:smart
+::   :*  %|
+::       `;;([bat=* pay=*] (cue q.q.trivial-contract))
+::       interface=~  ::  TODO
+::       types=~      ::  TODO
+::       0xdada.dada     ::  id
+::       0xdada.dada     ::  lord
+::       0xdada.dada     ::  holder
+::       town-id         ::  town-id
+::   ==
+:: ::
+:: ::  NFT stuff
+:: =/  nft-metadata-grain
+::   ^-  grain:smart
+::   :*  %&
+::       `@`'nftsalt'
+::       :*  name='Monkey JPEGs'
+::           symbol='BADART'
+::           attributes=(silt ~['hair' 'eyes' 'mouth'])
+::           supply=1
+::           cap=~
+::           mintable=%.n
+::           minters=~
+::           deployer=0x0
+::           salt=`@`'nftsalt'
+::       ==
+::       `@ux`'nft-metadata'
+::       0xcafe.babe
+::       0xcafe.babe
+::       town-id
+::   ==
+:: =/  item-1
+::   [1 (silt ~[['hair' 'red'] ['eyes' 'blue'] ['mouth' 'smile']]) 'a smiling monkey' 'ipfs://QmUbFVTm113tJEuJ4hZY2Hush4Urzx7PBVmQGjv1dXdSV9' %.y]
+:: =/  nft-acc-id  (fry-rice:smart 0xcafe.babe pubkey-1 town-id `@`'nftsalt')
+:: =/  nft-acc-grain
+::   :*  %&
+::       `@`'nftsalt'
+::       [`@ux`'nft-metadata' (malt ~[[1 item-1]]) ~ ~]
+::       nft-acc-id
+::       0xcafe.babe
+::       pubkey-1
+::       town-id
+::   ==
+:: =/  nft-wheat-grain
+::   ^-  grain:smart
+::   :*  %|
+::       `;;([bat=* pay=*] (cue q.q.nft-contract))
+::       interface=~  ::  TODO
+::       types=~      ::  TODO
+::       0xcafe.babe     ::  id
+::       0xcafe.babe     ::  lord
+::       0xcafe.babe     ::  holder
+::       town-id         ::  town-id
+::   ==
 ::
 =/  fake-granary
   ^-  granary
   =/  grains=(list:smart (pair:smart id:smart grain:smart))
-    :~  [id.zigs-wheat-grain zigs-wheat-grain]
-        [id.zigs-metadata-grain zigs-metadata-grain]
+    :~  [id.zigs-wheat [%| zigs-wheat]]
+        [id.zigs-metadata [%& zigs-metadata]]
         :: [id.nft-wheat-grain nft-wheat-grain]
         :: [id.nft-metadata-grain nft-metadata-grain]
         :: [id.publish-grain publish-grain]
@@ -134,10 +157,10 @@
         [zigs-3 cafe-zigs-grain]
         :: [nft-acc-id nft-acc-grain]
     ==
-  (~(gas by:smart *(map:smart id:smart grain:smart)) grains)
+  (gas:big:smart *(merk:smart id:smart grain:smart) grains)
 =/  fake-populace
   ^-  populace
-  %-  %~  gas  by:smart  *(map:smart id:smart @ud)
+  %+  gas:(bi:smart id:smart @ud)  *(merk:smart id:smart @ud)
   ~[[pubkey-1 0] [pubkey-2 0] [pubkey-3 0]]
 ::
 =/  =address:smart  (address-from-prv:key:ethereum private-key)


### PR DESCRIPTION
Was trying to play with zink/zock today and so updated `gen/sequencer/init.hoon` to work with new types. I have elided `interface` and `types` from `wheat`s.