### PR TITLE
Add asset escape hatch to `mill`

### DIFF
--- a/lib/zig/mill.hoon
+++ b/lib/zig/mill.hoon
@@ -266,7 +266,7 @@
       ^-  hatchling
       =/  from  [id.from.shell.egg nonce.from.shell.egg]
       ::  check for grain burn transaction
-      ?:  &(=(to.shell.egg 0x0) =(p.yolk.egg %burn))
+      ?:  &(=(0x0 to.shell.egg) =(%burn p.yolk.egg))
         (cook egg)
       ::  insert budget argument if egg is %give-ing zigs
       =?  q.yolk.egg  &(=(to.shell.egg zigs-wheat-id:smart) =(p.yolk.egg %give))

--- a/lib/zig/mill.hoon
+++ b/lib/zig/mill.hoon
@@ -267,7 +267,7 @@
       =/  from  [id.from.shell.egg nonce.from.shell.egg]
       ::  check for grain burn transaction
       ?:  &(=(0x0 to.shell.egg) =(%burn p.yolk.egg))
-        (cook egg)
+        (poach egg)
       ::  insert budget argument if egg is %give-ing zigs
       =?  q.yolk.egg  &(=(to.shell.egg zigs-wheat-id:smart) =(p.yolk.egg %give))
         [budget.shell.egg q.yolk.egg]
@@ -431,10 +431,10 @@
           ==
       ==
     ::
-    ::  +cook: handle special burn-only transactions, used for manually
+    ::  +poach: handle special burn-only transactions, used for manually
     ::  escaping some grain from a town. must be EITHER holder or lord to burn.
     ::
-    ++  cook
+    ++  poach
       |=  =egg:smart
       ^-  hatchling
       ::  TODO provide new error codes for these things

--- a/lib/zig/mill.hoon
+++ b/lib/zig/mill.hoon
@@ -253,14 +253,6 @@
   ::
   ++  farm
     |_  =granary
-    +$  hatchling
-      $:  hits=(list hints)
-          diff=(unit ^granary)
-          burned=^granary
-          =crow:smart
-          rem=@ud
-          =errorcode:smart
-      ==
     ::  +work: take egg and return diff granary, remaining budget,
     ::  and errorcode (0=success)
     ++  work
@@ -273,6 +265,9 @@
       |=  [=egg:smart hits=(list hints) burned=^granary]
       ^-  hatchling
       =/  from  [id.from.shell.egg nonce.from.shell.egg]
+      ::  check for grain burn transaction
+      ?:  &(=(to.shell.egg 0x0) =(p.yolk.egg %burn))
+        (cook egg)
       ::  insert budget argument if egg is %give-ing zigs
       =?  q.yolk.egg  &(=(to.shell.egg zigs-wheat-id:smart) =(p.yolk.egg %give))
         [budget.shell.egg q.yolk.egg]
@@ -423,7 +418,9 @@
           ::  only grains that proclaim us lord may be burned AND
           ::  burned cannot contain grain used to pay for gas
           ::
-          ::  NOTE: you *CAN* modify a grain in-contract before burning it.
+          ::  NOTE: you *can* modify a grain in-contract before burning it.
+          ::  the town-id of a burned grain marks the town which can REDEEM it.
+          ::
           =/  old  (get:big granary id)
           ?&  ?=(^ old)
               =(id id.p.grain)
@@ -432,6 +429,37 @@
               =(lord lord.p.u.old)
               !=(zigs.from id)
           ==
+      ==
+    ::
+    ::  +cook: handle special burn-only transactions, used for manually
+    ::  escaping some grain from a town. must be EITHER holder or lord to burn.
+    ::
+    ++  cook
+      |=  =egg:smart
+      ^-  hatchling
+      ::  TODO provide new error codes for these things
+      ::  TODO assign reasonable fixed cost for a burn
+      =/  fixed-burn-cost  1.000
+      ::  charge fixed cost for failed transactions too
+      ::  TODO should do this everywhere that we can inside +farm
+      =/  fail  [~ ~ ~ ~ (sub budget.shell.egg fixed-burn-cost) %6]
+      ::  argument for %burn must be a grain ID
+      ?.  ?=([id=@ux town=@ux] q.yolk.egg)          fail
+      ::  grain must exist in granary
+      ?~  to-burn=(get:big granary id.q.yolk.egg)   fail
+      ::  town ID must be different from current town
+      ?:  =(town.q.yolk.egg town-id.p.u.to-burn)    fail
+      ::  caller must be lord OR holder
+      ?.  ?|  =(lord.p.u.to-burn id.from.shell.egg)
+              =(holder.p.u.to-burn id.from.shell.egg)
+          ==
+        fail
+      ::  produce hatchling
+      :*  ~  ~
+          (gas:big *^granary ~[[id.p.u.to-burn u.to-burn]])
+          ~[[%burn `json`[%s (scot %ux id.p.u.to-burn)]]]
+          (sub budget.shell.egg fixed-burn-cost)
+          %0
       ==
     --
   --

--- a/sur/mill.hoon
+++ b/sur/mill.hoon
@@ -10,13 +10,28 @@
 +$  basket     (set [hash=@ux =egg:smart])   ::  transaction "mempool"
 +$  carton     (list [hash=@ux =egg:smart])  ::  basket that's been prioritized
 ::
-+$  diff  granary  ::  state transitions for one batch
++$  diff   granary  ::  state transitions for one batch
++$  burns  granary  ::  destroyed state with destination town set in-grain
+::
+::  final result of +mill-all
+::
 +$  state-transition
   $:  =land
       processed=carton
       hits=(list (list hints:zink))
       =diff
       crows=(list crow:smart)
-      burns=granary
+      =burns
+  ==
+::
+::  intermediate result in +farm
+::
++$  hatchling
+  $:  hits=(list hints:zink)
+      diff=(unit granary)
+      burned=granary
+      =crow:smart
+      rem=@ud
+      =errorcode:smart
   ==
 --

--- a/tests/lib/mill-2.hoon
+++ b/tests/lib/mill-2.hoon
@@ -162,7 +162,7 @@
 ++  fake-granary
   ^-  granary
   %+  gas:big  *(merk:merk id:smart grain:smart)
-  :~  :: [id.p:scry-wheat scry-wheat]
+  :~  [id.p:scry-wheat scry-wheat]
       [id.p:wheat:zigs wheat:zigs]
       ::  [id.p:temp-wheat temp-wheat]
       ::  [id.p:temp-grain temp-grain]
@@ -180,22 +180,6 @@
 ::
 ::  begin tests
 ::
-::  ++  test-mill-tester
-::    =/  =yolk:smart  [%look 0x1111.2222.3333]
-::    =/  shel=shell:smart
-::      [caller-1 ~ id.p:temp-wheat 1 1.000.000 town-id 0]
-::    =/  res=[fee=@ud =land burned=granary =errorcode:smart hits=(list) =crow:smart]
-::      %+  ~(mill mil miller town-id 1)
-::      fake-land  `egg:smart`[fake-sig shel yolk]
-::    ~&  >>  "output: {<crow.res>}"
-::    ~&  >>  "fee: {<fee.res>}"
-::    ~&  >>  "diff:"
-::    ~&  p.land.res
-::    ::  assert that our call went through
-::    %+  expect-eq
-::      !>(%0)
-::    !>(errorcode.res)
-::
 ++  test-mill-zigs-give
   =/  =yolk:smart  [%give holder-2:zigs 1.000 id.p:account-1:zigs `id.p:account-2:zigs]
   =/  shel=shell:smart
@@ -212,17 +196,36 @@
     !>(%0)
   !>(errorcode.res)
 ::
-::  ++  test-mill-trivial-scry
-::    =/  =yolk:smart  [%find 0x1.dead]
-::    =/  shel=shell:smart
-::      [caller-1 ~ id.p:scry-wheat 1 1.000.000 town-id 0]
-::    =/  res=[fee=@ud =land burned=granary =errorcode:smart hits=(list) =crow:smart]
-::      %+  ~(mill mil miller town-id 1)
-::      fake-land  `egg:smart`[fake-sig shel yolk]
-::    ~&  >  "output: {<crow.res>}"
-::    ~&  >  "fee: {<fee.res>}"
-::    ::  assert that our call went through
-::    %+  expect-eq
-::      !>(%0)
-::    !>(errorcode.res)
+++  test-mill-trivial-scry
+  =/  =yolk:smart  [%find id.p:account-1:zigs]
+  =/  shel=shell:smart
+    [caller-1 ~ id.p:scry-wheat 1 1.000.000 town-id 0]
+  =/  res=[fee=@ud =land burned=granary =errorcode:smart hits=(list) =crow:smart]
+    %+  ~(mill mil miller town-id 1)
+    fake-land  `egg:smart`[fake-sig shel yolk]
+  ~&  >  "output: {<crow.res>}"
+  ~&  >  "fee: {<fee.res>}"
+  ::  assert that our call went through
+  %+  expect-eq
+    !>(%0)
+  !>(errorcode.res)
+::
+++  test-mill-simple-burn
+  ::               id of grain to burn, destination town id
+  =/  =yolk:smart  [%burn id.p:account-1:zigs 0x2]
+  =/  shel=shell:smart
+    [caller-1 ~ 0x0 1 1.000.000 town-id 0]
+  =/  res=[fee=@ud =land burned=granary =errorcode:smart hits=(list) =crow:smart]
+    %+  ~(mill mil miller town-id 1)
+    fake-land  `egg:smart`[fake-sig shel yolk]
+  ~&  >  "output: {<crow.res>}"
+  ~&  >  "fee: {<fee.res>}"
+  ::  assert that our call went through
+  ;:  weld
+    (expect-eq !>(%0) !>(errorcode.res))
+  ::
+    (expect-eq !>(1.000) !>(fee.res))
+  ::
+    (expect-eq !>(%.y) !>((has:big burned.res id.p:account-1:zigs)))
+  ==
 --


### PR DESCRIPTION
Finally, burns will be real. With this addition to `mill`, one can submit a special `%burn` transaction to a sequencer.

The burner must be either `holder` or `lord` of the grain in question.

A burn transaction is marked by setting the `to` contract ID to `0x0` and the action to `[%burn {id} {town-id}]`, where {id} is of the grain in question, and {town-id} is the town the burned grain is destined for.

Burns done this way produce an event noting the burn.

What else needs to be added here? So far, we're just creating the burn -- the "reconstitute" transaction will come later, as we're waiting to see how to gather that information from the rollup. Burns will be one-way until then!