### PR TITLE
add %faucet

### DIFF
--- a/app/faucet.hoon
+++ b/app/faucet.hoon
@@ -1,0 +1,107 @@
+::  faucet [UQ| DAO]:
+::
+::  Give out native token on testnet
+::
+::
+::    ##  Pokes
+::
+::    %faucet-action:
+::      Requests from outside.
+::      %open: Request native token from faucet,
+::             to be sent to given address.
+::    %faucet-configure:
+::      Change state of %faucet app.
+::
+::
+/-  f=faucet,
+    w=wallet
+/+  agentio,
+    dbug,
+    default-agent,
+    verb,
+    smart=zig-sys-smart
+::
+|%
++$  card  card:agent:gall
+--
+::
+=|  state-0:f
+=*  state  -
+::
+%-  agent:dbug
+%+  verb  |
+^-  agent:gall
+|_  =bowl:gall
++*  this  .
+    def   ~(. (default-agent this %|) bowl)
+    io    ~(. agentio bowl)
+::
+++  on-init
+  :-  ~
+  %=  this
+      gas     [rate=1 budget=1.000.000]
+      volume  1.000.000.000.000.000.000
+  ==
+++  on-save  !>(state)
+++  on-load
+  |=  old-vase=vase
+  =/  old  !<(versioned-state:f old-vase)
+  ?-    -.old
+      %0
+      `this(state old)
+  ==
+::
+++  on-poke
+  |=  [=mark =vase]
+  |^  ^-  (quip card _this)
+  ?+  mark  (on-poke:def mark vase)
+    %faucet-action     (handle-action !<(action:f vase))
+    %faucet-configure  (handle-configure !<(configure:f vase))
+  ==
+  ::
+  ++  handle-action
+    |=  =action:f
+    ^-  (quip card _this)
+    ?-    -.action
+        %open
+      ?~  town-info=(~(get by town-infos) town-id.action)
+        ~|("%faucet: invalid town. Valid towns: {<~(key by town-infos)>}" !!)
+      :_  this
+      :_  ~
+      %+  ~(poke-our pass:io /open-poke-wire)
+        %wallet
+      :-  %zig-wallet-poke
+      !>  ^-  wallet-poke:w
+      :*  %submit
+          from=address.u.town-info
+          to=zigs-wheat.u.town-info
+          town=town-id.action
+          gas=gas
+          :^  %give  to=address.action  amount=volume
+          grain=zigs-rice.u.town-info
+      ==
+    ==
+  ::
+  ++  handle-configure
+    |=  c=configure:f
+    ^-  (quip card _this)
+    ?>  =(our.bowl src.bowl)
+    ?-    -.c
+        %edit-gas     `this(gas gas.c)
+        %edit-volume  `this(volume volume.c)
+        %put-town
+      :-  ~
+      %=  this
+          town-infos
+        (~(put by town-infos) town-id.c town-info.c)
+      ==
+    ==
+  --
+::
+++  on-watch  on-watch:def
+++  on-leave  on-leave:def
+++  on-peek   on-peek:def
+++  on-agent  on-agent:def
+++  on-arvo   on-arvo:def
+++  on-fail   on-fail:def
+--

--- a/mar/faucet/action.hoon
+++ b/mar/faucet/action.hoon
@@ -1,0 +1,15 @@
+/-  f=faucet
+::
+|_  =action:f
+++  grab
+  |%
+  ++  noun  action:f
+  --
+::
+++  grow
+  |%
+  ++  noun  action
+  --
+::
+++  grad  %noun
+--

--- a/mar/faucet/configure.hoon
+++ b/mar/faucet/configure.hoon
@@ -1,0 +1,15 @@
+/-  f=faucet
+::
+|_  =config:f
+++  grab
+  |%
+  ++  noun  config:f
+  --
+::
+++  grow
+  |%
+  ++  noun  config
+  --
+::
+++  grad  %noun
+--

--- a/sur/faucet.hoon
+++ b/sur/faucet.hoon
@@ -1,0 +1,30 @@
+/+  smart=zig-sys-smart
+::
+|%
++$  action
+  $%  [%open town-id=id:smart =address:smart]
+  ==
+::
++$  configure
+  $%  [%edit-gas gas=[rate=@ud budget=@ud]]
+      [%edit-volume volume=@ud]
+      [%put-town town-id=id:smart =town-info]
+  ==
+::
++$  versioned-state
+  $%  state-0
+  ==
+::
++$  state-0
+  $:  %0
+      town-infos=(map id:smart town-info)
+      gas=[rate=@ud budget=@ud]
+      volume=@ud
+  ==
+::
++$  town-info
+  $:  =address:smart
+      zigs-rice=id:smart
+      zigs-wheat=id:smart
+  ==
+--

--- a/ted/open-faucet.hoon
+++ b/ted/open-faucet.hoon
@@ -1,0 +1,30 @@
+/-  spider,
+    f=faucet
+/+  strandio,
+    smart=zig-sys-smart
+::
+=*  strand     strand:spider
+=*  poke       poke:strandio
+::
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+=/  arg-mold
+  $:  faucet-host=@p
+      town-id=id:smart
+      =address:smart
+  ==
+=/  args  !<((unit arg-mold) arg)
+?~  args
+  ~&  >  "open-faucet: Poke the %faucet app on faucet-host"
+  ~&  >  "             to receive some native tokens to address"
+  ~&  >  "Usage: -zig!open-faucet faucet-host town-id address"
+=*  faucet-host  faucet-host.u.args
+=*  town-id      town-id.u.args
+=*  address      address.u.args
+::
+;<  ~  bind:m
+  %^  poke  [faucet-host %faucet]  %faucet-action
+  !>(`action:f`[%open town-id address])
+(pure:m !>(~))


### PR DESCRIPTION
Add testnet `%faucet` to dispense native tokens.

To test, add `%faucet` to desk.bill. Then:

```
::  on ~zod
:faucet &faucet-configure [%put-town 0x0 0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 0x89a0.89d8.dddf.d13a.418c.0d93.d4b4.e7c7.637a.d56c.96c0.7f91.3a14.8174.c7a7.71e6 0x74.6361.7274.6e6f.632d.7367.697a]

::  on secondary ship, e.g., ~nec
:uqbar &zig-wallet-poke [%import-seed 'post fitness extend exit crack question answer fruit donkey quality emotion draw section width emotion leg settle bulb zero learn solution dutch target kidney' 'squid' 'nickname']
-zig!open-faucet ~zod 0x0 0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de
```

which should submit a tx on the sequencer to transfer 1 zig from ~zod to ~nec

To make this work on a testnet, start the testnet with an address with many zigs and point `%faucet` to that address using the `%faucet-configure` poke above.

If we are worried about spammers/trolls, may want to add a rate limiter, so an address and/or ship can only request one zig per unit time.