### PR TITLE
Slightly better compiler errors

### DIFF
--- a/lib/ziggurat.hoon
+++ b/lib/ziggurat.hoon
@@ -92,16 +92,20 @@
   |^
   =/  first  (mule |.((parse-main main.proj)))
   ?:  ?=(%| -.first)
-    %|^(get-formatted-error (snoc p.first 'error parsing main:'))
+    :-  %|
+    %-  get-formatted-error
+    (snoc (scag 4 p.first) 'error parsing main:')
   =/  second  (mule |.((parse-libs -.p.first)))
   ?:  ?=(%| -.second)
-    %|^(get-formatted-error (snoc p.second 'error parsing libraries:'))
+    :-  %|
+    %-  get-formatted-error
+    (snoc (scag 3 p.second) 'error parsing library:')
   =/  third  (mule |.((build-libs p.second)))
   ?:  ?=(%| -.third)
-    %|^(get-formatted-error (snoc p.third 'error building libraries:'))
+    %|^(get-formatted-error (snoc (scag 1 p.third) 'error building libraries:'))
   =/  fourth  (mule |.((build-main +.p.third +.p.first)))
   ?:  ?=(%| -.fourth)
-    %|^(get-formatted-error (snoc p.fourth 'error building libraries:'))
+    %|^(get-formatted-error (snoc (scag 1 p.fourth) 'error building main:'))
   %&^[bat=p.fourth pay=-.p.third]
   ::
   ++  parse-main  ::  first
@@ -122,7 +126,7 @@
     =/  libraries=hoon  [%clsg braw]
     :-  q:(~(mint ut p.smart-lib) %noun libraries)
     (slap smart-lib libraries)
-  ::
+  ::1
   ++  build-main  ::  fourth
     |=  [payload=vase contract=hoon]
     ^-  *

--- a/lib/ziggurat.hoon
+++ b/lib/ziggurat.hoon
@@ -126,7 +126,7 @@
     =/  libraries=hoon  [%clsg braw]
     :-  q:(~(mint ut p.smart-lib) %noun libraries)
     (slap smart-lib libraries)
-  ::1
+  ::
   ++  build-main  ::  fourth
     |=  [payload=vase contract=hoon]
     ^-  *

--- a/lib/zink/conq.hoon
+++ b/lib/zink/conq.hoon
@@ -189,7 +189,8 @@
   %-  mean  %-  flop
   =/  lyn  p.hair
   =/  col  q.hair
-  :~  leaf+"syntax error at [{<lyn>} {<col>}]"
+  :~  leaf+"syntax error"
+      leaf+"\{{<lyn>} {<col>}}"
       leaf+(runt [(dec col) '-'] "^")
       leaf+(trip (snag (dec lyn) (to-wain:format (crip tex))))
   ==


### PR DESCRIPTION
Change conq.hoon and lib/ziggurat.hoon to make contract compile errors that match enough, such that ziggurat frontend can parse line numbers and red-squiggly-underline the site of error.