### PR TITLE
uqbar: only remove removed sources

### DIFF
--- a/app/uqbar.hoon
+++ b/app/uqbar.hoon
@@ -138,7 +138,7 @@
     ::
     ++  handle-action
       |=  act=action:u
-      ^-  (quip card _state)
+      |^  ^-  (quip card _state)
       ?>  =(src.bowl our.bowl)
       ?-    -.act
           %set-wallet-source
@@ -168,7 +168,10 @@
             [%uqbar-action !>(`action:u`[%ping ~])]
         %=  state
             indexer-sources-ping-results
-          ?^(pings-timedout ~ indexer-sources-ping-results)  :: TODO: can do better?
+          %^    remove-from-ping-results
+              town-id.act
+            source.act
+          indexer-sources-ping-results
         ::
             indexer-sources
           (~(del ju indexer-sources) town-id.act source.act)
@@ -184,12 +187,51 @@
             `(~(watch pass:io p) -.indexers p)  ::  TODO: do better here
         %=  state
             indexer-sources-ping-results
-          ?^(pings-timedout ~ indexer-sources-ping-results)  :: TODO: can do better?
+          (set-sources-remove-from-ping-results towns.act)
         ::
             indexer-sources
           (~(gas by *(map id:smart (set dock))) towns.act)
         ==
       ==
+      ::
+      ++  remove-from-ping-results
+        |=  $:  town-id=id:smart
+                source=dock
+                =indexer-sources-ping-results:u
+            ==
+        ^-  indexer-sources-ping-results:u
+        =/  old
+          %+  ~(gut by indexer-sources-ping-results)
+          town-id  [~ ~ ~ ~]
+        ?:  ?=([~ ~ ~ ~] old)  indexer-sources-ping-results
+        %+  ~(put by indexer-sources-ping-results)
+          town-id
+        :^    (~(del in previous-up.old) source)
+            (~(del in previous-down.old) source)
+          (~(del in newest-up.old) source)
+        (~(del in newest-down.old) source)
+      ::
+      ++  set-sources-remove-from-ping-results
+        |=  towns=(list [town-id=id:smart (set dock)])
+        ^-  indexer-sources-ping-results:u
+        ?~  towns  indexer-sources-ping-results
+        =*  town-id  town-id.i.towns
+        =/  docks=(list dock)  ~(tap in +.i.towns)
+        %=  $
+            towns  t.towns
+            indexer-sources-ping-results
+          |-
+          ?~  docks  indexer-sources-ping-results
+          %=  $
+              docks  t.docks
+              indexer-sources-ping-results
+            %^    remove-from-ping-results
+                town-id
+              i.docks
+            indexer-sources-ping-results
+          ==
+        ==
+      --
     ::
     ++  handle-write
       |=  =write:u


### PR DESCRIPTION
Remove from `indexer-sources-ping-results` on `%remove-source` and `%set-sources` more precisely.

Not sure this was the bug you were seeing, but it is certainly better than how we were previously doing it @dr-frmr 