### PR TITLE
indexer: add `/json`-prepended subscription paths

### DIFF
--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -443,6 +443,7 @@
     ?.  ?=(%fact -.sign)       (on-agent:def wire sign)
     ?.  ?=(%indexer-update p.cage.sign)  (on-agent:def wire sign)
     =/  =update:ui  !<(=update:ui q.cage.sign)
+    ?~  update             `this
     ?.  ?=(%egg -.update)  `this
     =/  our-id=@ux  ?:(?=([@ @ @ ~] wire) (slav %ux i.t.t.wire) (slav %ux i.t.t.t.wire))
     =+  our-txs=(~(gut by transaction-store.state) our-id [sent=~ received=~])

--- a/ted/watch-indexer.hoon
+++ b/ted/watch-indexer.hoon
@@ -21,13 +21,23 @@
   (watch watch-wire [our.bowl %indexer] watch-path)
 ~&  >  "watch-indexer: watching {<watch-path>}..."
 ;<  =cage  bind:m  (take-fact watch-wire)
-~&  >  "watch-indexer: got:"
-~&  >  "watch-indexer:  {<cage>}"
-?:  ?=(%indexer-update p.cage)
-  ~&  >  "watch-indexer:  {<!<(update:ui q.cage)>}"
+:: ~&  >  "watch-indexer: got:"
+:: ~&  >  "watch-indexer:  {<cage>}"
+;<  ~  bind:m  (leave watch-wire [our.bowl %indexer])
+?+    p.cage
+      ~&  >  "watch-indexer: done"
+      (pure:m !>(~))
+    %indexer-update
+  ~&  >  "watch-indexer:  got:"
+  ~&  !<(update:ui q.cage)
+  ~&  >  "watch-indexer:  done"
+  (pure:m !>(~))
+::
+    %json
+  ~&  >  "watch-indexer:  got:"
+  ~&  !<(json q.cage)
+  ~&  (en-json:html !<(json q.cage))
   ;<  ~  bind:m  (leave watch-wire [our.bowl %indexer])
   ~&  >  "watch-indexer:  done"
   (pure:m !>(~))
-;<  ~  bind:m  (leave watch-wire [our.bowl %indexer])
-~&  >  "watch-indexer:  done"
-(pure:m !>(~))
+==


### PR DESCRIPTION
With `jold`s, scrys can be prepended with `/json` in order to have the output be JSON and the data/actions of grains/eggs be molded with the `lord`s `interface`/`types`. This PR adds a similar prepend option to subscriptions.