### PR TITLE
indexer: ensure catchup to proper state

### DIFF
--- a/app/indexer.hoon
+++ b/app/indexer.hoon
@@ -287,7 +287,7 @@
     |=  =path
     ^-  (unit (unit cage))
     ?:  =(/x/dbug/state path)
-      ~  ::  Don't send :indexer +dbug %path-does-not-exist.
+      ``[%noun !>(`_state`state)]
     ?.  ?=  $?  [@ @ @ ~]  [@ @ @ @ @ @ ~]
                 [@ @ @ @ ~]  [@ @ @ @ @ ~]
             ==
@@ -417,6 +417,24 @@
         [%indexer-catchup-update ~]
       ?+    -.sign  (on-agent:def wire sign)
           %fact
+        ::  Reset state to initial conditions: this happens
+        ::   automagically `+on-load`, but not here.
+        ::   If don't do this, can get bad state starting
+        ::   up a new indexer.
+        =:  batches-by-town         ~
+            capitol                 ~
+            sequencer-update-queue  ~
+            town-update-queue       ~
+            old-sub-updates         ~
+            egg-index               ~
+            from-index              ~
+            grain-index             ~
+            :: grain-eggs-index        ~
+            holder-index            ~
+            lord-index              ~
+            to-index                ~
+            newest-batch-by-town    ~
+        ==
         `this(state (set-state-from-vase q.cage.sign))
       ==
     ==
@@ -720,12 +738,12 @@
 ++  set-state-from-vase
   |=  state-vase=vase
   ^-  _state
-  =/  new-base-state  !<(versioned-state:ui state-vase)
-  ?-    -.new-base-state
+  =+  !<(=versioned-state:ui state-vase)
+  ?-    -.versioned-state
       %0
-    :-  new-base-state(old-sub-updates ~)
+    :-  versioned-state(old-sub-updates ~)
     %-  inflate-state
-    ~(tap by batches-by-town.new-base-state)
+    ~(tap by batches-by-town.versioned-state)
   ==
 ::
 ++  inflate-state
@@ -758,7 +776,10 @@
           timestamp.i.batches-list
           %.n
       ==
-    $(batches-list t.batches-list)
+    %=  $
+        batches-list     t.batches-list
+        temporary-state  temporary-state
+    ==
   --
 ::
 ++  serve-update

--- a/readme.md
+++ b/readme.md
@@ -251,9 +251,9 @@ The following two examples assume `~zod` is the host:
 
 ### Indexing on an existing testnet
 ```hoon
-:indexer &indexer-catchup [~zod %indexer]
 :indexer &set-sequencer [~zod %sequencer]
 :indexer &set-rollup [~zod %rollup]
+:indexer &indexer-catchup [~zod %indexer]
 :uqbar|set-sources 0x0 ~[our]
 ```
 In this example, not all the hosts need be the same ship.

--- a/sur/indexer.hoon
+++ b/sur/indexer.hoon
@@ -7,7 +7,7 @@
       %egg
       %from
       %grain
-      %grain-eggs
+      :: %grain-eggs
       %holder
       %lord
       %to
@@ -73,7 +73,7 @@
   $:  =egg-index
       from-index=second-order-index
       grain-index=batch-index
-      grain-eggs-index=second-order-index
+      :: grain-eggs-index=second-order-index
       holder-index=second-order-index
       lord-index=second-order-index
       to-index=second-order-index


### PR DESCRIPTION
The point of this fix, aside from increasing robustness, is that we want to switch the order of `%indexer-catchup` with `%set-sequencer` and `%set-rollup` to avoid a situation where:

1. New user runs `%indexer-catchup`.
2. While they are catching up, some number of new batches come out.
3. User subscribes to sequencer and rollup.
4. End result: user is missing some batches.

What is happening is that `%indexer-catchup` was not acting on a null state, and so, since the sequencer and rollup will give us current state upon subscribe, the most recent batch will incorrectly appear in the first batch.

To see bug on master:

```
::  on ~zod
::  setup
:rollup|activate
:sequencer|init our 0x0 0xc9f8.722e.78ae.2e83.0dd9.e8b9.db20.f36a.1bc4.c704.4758.6825.c463.1ab6.daee.e608
:indexer &set-sequencer [our %sequencer]
:indexer &set-rollup [our %rollup]
:uqbar|set-sources 0x0 ~[our]
:uqbar &zig-wallet-poke [%import-seed 'uphold apology rubber cash parade wonder shuffle blast delay differ help priority bleak ugly fragile flip surge shield shed mistake matrix hold foam shove' 'squid' 'nickname']

::  submit a tx on ~zod: there are now 2 batches
:uqbar &zig-wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x74.6361.7274.6e6f.632d.7367.697a town=0x0 action=[%give to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de amount=123.456 grain=0x89a0.89d8.dddf.d13a.418c.0d93.d4b4.e7c7.637a.d56c.96c0.7f91.3a14.8174.c7a7.71e6]]
:uqbar &zig-wallet-poke [%submit from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 hash=[0x939e.f411.f950.2b8e.b0f7.e331.f7f4.b386] gas=[rate=1 bud=1.000.000]]

::  on ~nec
::  note order is %indexer-catchup LAST, whereas in readme (until this PR) we recommended it FIRST
:indexer &set-sequencer [~zod %sequencer]
:indexer &set-rollup [~zod %rollup]
:indexer &indexer-catchup [~zod %indexer]
```

I originally tried, e.g.,

```
=.  state  *_state
```

but it did not work, perhaps because it is an alias?