### PR TITLE
indexer: fix `/holder` subscription

### DIFF
--- a/app/indexer.hoon
+++ b/app/indexer.hoon
@@ -109,6 +109,12 @@
 ::    /holder/[holder-id=@ux]
 ::    /holder/[town-id=@ux]/[holder-id=@ux]:
 ::      A stream of new activity of given holder.
+::      If a held grain changes holders, the final update
+::      sent for that grain will have the updated holder.
+::      Thus, applications will need to check the holder
+::      field and update their state as appropriate when
+::      it has changed; subsequent updates will not include
+::      that grain.
 ::      Reply on-watch is entire history of held grains.
 ::    /id/[id=@ux]
 ::    /id/[town-id=@ux]/[id=@ux]:

--- a/app/indexer.hoon
+++ b/app/indexer.hoon
@@ -313,7 +313,7 @@
         read-query-payload-from-args
       %-  make-peek-update
       ?~  query-payload  [%path-does-not-exist ~]
-      (get-hashes u.query-payload only-newest)
+      (get-hashes u.query-payload only-newest %.y)
     ::
         ?([%id @ ~] [%id @ @ ~])
       =/  query-payload=(unit query-payload:ui)
@@ -337,7 +337,12 @@
         read-query-payload-from-args
       %-  make-peek-update
       ?~  query-payload  [%path-does-not-exist ~]
-      (serve-update query-type u.query-payload only-newest)
+      %:  serve-update
+          query-type
+          u.query-payload
+          only-newest
+          %.y
+      ==
     ::
         [%batch-order @ ~]
       =/  town-id=@ux  (slav %ux i.t.args)
@@ -644,21 +649,22 @@
 ++  get-ids
   |=  [qp=query-payload:ui only-newest=?]
   ^-  update:ui
-  =/  from=update:ui  (serve-update %from qp only-newest)
-  =/  to=update:ui    (serve-update %to qp only-newest)
+  =/  from=update:ui  (serve-update %from qp only-newest %.n)
+  =/  to=update:ui    (serve-update %to qp only-newest %.n)
   (combine-egg-updates ~[from to])
 ::
 ++  get-hashes
-  |=  [qp=query-payload:ui only-newest=?]
+  |=  [qp=query-payload:ui only-newest=? should-filter=?]
   ^-  update:ui
-  =/  batch=update:ui   (serve-update %batch qp only-newest)
-  =/  egg=update:ui     (serve-update %egg qp only-newest)
-  =/  from=update:ui    (serve-update %from qp only-newest)
-  =/  grain=update:ui   (serve-update %grain qp only-newest)
-  =/  holder=update:ui  (serve-update %holder qp only-newest)
-  =/  lord=update:ui    (serve-update %lord qp only-newest)
-  =/  to=update:ui      (serve-update %to qp only-newest)
-  =/  town=update:ui    (serve-update %town qp only-newest)
+  =*  options  [only-newest should-filter]
+  =/  batch=update:ui   (serve-update %batch qp options)
+  =/  egg=update:ui     (serve-update %egg qp options)
+  =/  from=update:ui    (serve-update %from qp options)
+  =/  grain=update:ui   (serve-update %grain qp options)
+  =/  holder=update:ui  (serve-update %holder qp options)
+  =/  lord=update:ui    (serve-update %lord qp options)
+  =/  to=update:ui      (serve-update %to qp options)
+  =/  town=update:ui    (serve-update %town qp options)
   :: =/  grain-eggs=update:ui
   ::   (serve-update %grain-eggs qp only-newest)
   %^  combine-updates  ~[batch town]  ~[egg from to]
@@ -783,7 +789,11 @@
   --
 ::
 ++  serve-update
-  |=  [=query-type:ui =query-payload:ui only-newest=?]
+  |=  $:  =query-type:ui
+          =query-payload:ui
+          only-newest=?
+          should-filter=?
+      ==
   ^-  update:ui
   =/  get-appropriate-batch
     ?.  only-newest  get-batch
@@ -961,26 +971,20 @@
       =/  =update:ui  create-update
       ?~  update  ~
       ?+    -.update  ~|("indexer: get-second-order unexpected return type" !!)
-          %egg    update(eggs (filter-eggs eggs.update))
-          %grain  update(grains (filter-grains grains.update))
-          %newest-egg    ?.((is-egg-hit +.+.update) ~ update)
-          %newest-grain  ?.((is-grain-hit +.+.update) ~ update)
-      ==
+          %newest-egg  update
+          %egg         update
       ::
-      ++  is-egg-hit
-        |=  value=egg-update-value:ui
-        ^-  ?
-        =/  query-hash=id:smart
-          ?:  ?=(@ query-payload)  query-payload
-          ?>  ?=([@ @] query-payload)
-          +.query-payload
-        ?|  ?&  ?=(%from query-type)
-                =(query-hash id.from.shell.egg.value)
-            ==
-            ?&  ?=(%to query-type)
-                =(query-hash contract.shell.egg.value)
-            ==
+          %newest-grain
+        ?.  should-filter  update
+        ?.((is-grain-hit +.+.update) ~ update)
+      ::
+          %grain
+        %=  update
+            grains
+          ?.  should-filter  grains.update
+          (filter-grains grains.update)
         ==
+      ==
       ::
       ++  is-grain-hit
         |=  value=grain-update-value:ui
@@ -989,25 +993,11 @@
           ?:  ?=(@ query-payload)  query-payload
           ?>  ?=([@ @] query-payload)
           +.query-payload
-        ::  hack to get around grain's `each`
-        =/  [holder=id:smart lord=id:smart]
-          ?:  -.grain.value
-            [holder.p.grain.value lord.p.grain.value]
-          [holder.p.grain.value lord.p.grain.value]
+        =*  holder  holder.p.grain.value
+        =*  lord    lord.p.grain.value
         ?|  &(?=(%holder query-type) =(query-hash holder))
             &(?=(%lord query-type) =(query-hash lord))
         ==
-      ::
-      ++  filter-eggs
-        |=  eggs=(map id:smart egg-update-value:ui)
-        ^-  (map id:smart egg-update-value:ui)
-        %-  ~(gas by *(map id:smart egg-update-value:ui))
-        %+  roll  ~(tap by eggs)
-        |=  $:  [egg-id=id:smart =egg-update-value:ui]
-                out=(list [id:smart egg-update-value:ui])
-            ==
-        ?.  (is-egg-hit egg-update-value)  out
-        [[egg-id egg-update-value] out]
       ::
       ++  filter-grains  ::  TODO: generalize w/ `+diff-update-grains`
         |=  grains=(jar id:smart grain-update-value:ui)
@@ -1049,7 +1039,6 @@
             ?:  ?=(%egg -.next-update)
               (~(uni by eggs.out) eggs.next-update)
             ?>  ?=(%newest-egg -.next-update)
-            ?.  (is-egg-hit +.+.next-update)  eggs.out
             (~(put by eggs.out) +.next-update)
           ==
         ::
@@ -1060,7 +1049,6 @@
             ?:  ?=(%grain -.next-update)
               (~(uni by grains.out) grains.next-update)  ::  TODO: can this clobber?
             ?>  ?=(%newest-grain -.next-update)
-            ?.  (is-grain-hit +.+.next-update)  grains.out
             (~(add ja grains.out) +.next-update)
           ==
         ::
@@ -1069,7 +1057,6 @@
               %egg
             %=  next-update
                 eggs
-              ?.  (is-egg-hit +.+.out)  eggs.next-update
               (~(put by eggs.next-update) +.out)
             ==
           ::
@@ -1085,7 +1072,6 @@
               %grain
             %=  next-update
                 grains
-              ?.  (is-grain-hit +.+.out)  grains.next-update
               (~(add ja grains.next-update) +.out)  ::  TODO: ordering?
             ==
           ::
@@ -1095,8 +1081,7 @@
             %~  add  ja
             %.  +.out
             %~  add  ja
-            ^*  %+  jar  id:smart
-            [@da batch-location:ui grain:smart]
+            *(jar id:smart grain-update-value:ui)
           ==
         ==
       --
@@ -1250,8 +1235,7 @@
   ::
   ++  make-all-sub-cards
     ^-  [(list card) (list [path update:ui])]
-    =/  sub-paths=(jug @tas path)
-      make-sub-paths
+    =/  sub-paths=(jug @tas path)  make-sub-paths
     |^
     =/  out=(pair (list (list card)) (list (list [path update:ui])))
       %+  roll
@@ -1294,10 +1278,11 @@
         [(slav %ux i.sub-path) (slav %ux i.t.sub-path)]
       =/  =update:ui
         ?+    query-type  !!
-            %hash  (get-hashes payload %.y)
-            %id    (get-ids payload %.y)
-            ?(%grain %holder %lord %town)
-          (serve-update query-type payload %.y)
+            %hash    (get-hashes payload %.y %.n)
+            %holder  (serve-update query-type payload %.y %.n)
+            %id      (get-ids payload %.y)
+            ?(%grain %lord %town)
+          (serve-update query-type payload %.y %.y)
         ==
       ?~  update  out
       =/  total-path=path  [query-type sub-path]
@@ -1327,11 +1312,13 @@
     ++  compute-update-diff
       |=  [new=update:ui sub-path=path]
       |^  ^-  update:ui
+      =*  query-type  -.sub-path
       =/  old=update:ui
         (~(gut by old-sub-updates) sub-path ~)
       ?~  old             new
       ?.  =(-.old -.new)  ~  ::  require same type updates
       ?+    -.old         ~
+      ::  TODO: simplify where we don't need diffs
           %batch
         ?>  ?=(%batch -.new)
         ?~  diff=(diff-update-maps batches.old batches.new)
@@ -1353,7 +1340,9 @@
         ?>  ?=(%grain -.new)
         ?~  diff=(diff-update-grains grains.old grains.new)
           ~
-        [%grain diff]
+        :-  %grain
+        ?.  ?=(%holder query-type)  diff
+        (filter-holder-held-in-last-batch diff grains.old)
       ::
           %hash
         ?>  ?=(%hash -.new)
@@ -1363,6 +1352,10 @@
           (diff-update-maps eggs.old eggs.new)
         =/  grain-diff=(jar id:smart grain-update-value:ui)
           (diff-update-grains grains.old grains.new)
+        =.  grain-diff
+        ?.  ?=(%holder query-type)  grain-diff
+        %+  filter-holder-held-in-last-batch  grain-diff
+        grains.old
         ?:  ?&  ?=(~ batch-diff)
                 ?=(~ egg-diff)
                 ?=(~ grain-diff)
@@ -1394,6 +1387,33 @@
         ?~  diff=(diff-update-value +.+.old +.+.new)  ~
         [%newest-grain grain-id.new u.diff]
       ==
+      ::
+      ++  filter-holder-held-in-last-batch
+        |=  $:  diff-grains=(jar id:smart grain-update-value:ui)
+                old-grains=(jar id:smart grain-update-value:ui)
+            ==
+        ^-  (jar id:smart grain-update-value:ui)
+        =/  holder-id=id:smart
+          %+  slav  %ux
+          ?:  ?=  ?([%holder @ ~] [%holder @ %no-init ~])
+              sub-path
+            i.t.sub-path
+          ?>  ?=  ?([%holder @ @ ~] [%holder @ @ %no-init ~])
+              sub-path
+          i.t.t.sub-path
+        %-  %~  gas  by
+            *(map id:smart (list grain-update-value:ui))
+        %+  roll  ~(tap by diff-grains)
+        |=  $:  [=id:smart diff-vals=(list grain-update-value:ui)]
+                out=(list [id:smart (list grain-update-value:ui)])
+            ==
+        ?~  old-vals=(~(get ja old-grains) id)
+          [[id diff-vals] out]
+        ~|  "expected newest"
+        ?>  =(1 (lent diff-vals))
+        ?>  =(1 (lent old-vals))
+        ?.  =(holder-id holder.p.grain.i.old-vals)  out
+        [[id diff-vals] out]
       ::
       ++  diff-update-value
         |*  [old-val=[@da * *] new-val=[@da * *]]

--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ The `%wallet` will send the transaction hash on a subscription wire as well as p
 :uqbar &zig-wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x74.6361.7274.6e6f.632d.7367.697a town=0x0 action=[%give to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de amount=123.456 grain=0x89a0.89d8.dddf.d13a.418c.0d93.d4b4.e7c7.637a.d56c.96c0.7f91.3a14.8174.c7a7.71e6]]
 
 ::  Send an NFT.
-:uqbar &zig-wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x53f9.b35a.4884.8c46.4c53.1846.cee8.0e4c.e898.440b.18d8.ebe8.decd.c3af.617e.89af town=0x0 action=[%give-nft to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de grain=0x273a.33fb.ac87.6864.4181.38cf.8b07.48f8.be05.ab08.3055.c38e.9977.de2b.80e8.4a3f]]
+:uqbar &zig-wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0xc9fb.6b1b.e8b2.7b73.65e4.700f.9665.24c8.9388.2cde.fadd.c422.eb9a.3624.ca5d.014d town=0x0 action=[%give-nft to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de grain=0x7b61.8ce0.26ec.f2b9.3bc9.5800.ba7f.164e.89ba.817b.e0d9.5cfd.96bc.c12a.5c29.00a1]]
 
 ::  Use the custom transaction interface to send zigs tokens.
 :uqbar &zig-wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x74.6361.7274.6e6f.632d.7367.697a town=0x0 action=[%noun [%give to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de amount=69.000 from-account=0x89a0.89d8.dddf.d13a.418c.0d93.d4b4.e7c7.637a.d56c.96c0.7f91.3a14.8174.c7a7.71e6 to-account=`0xd79b.98fc.7d3b.d71b.4ac9.9135.ffba.cc6c.6c98.9d3b.8aca.92f8.b07e.a0a5.3d8f.a26c]]]


### PR DESCRIPTION
Second-order indices store a hash of the underlying item they reference. For example, `holder-index` stores a `grain-id`, so that when a user queries for grains held by `0xdead.beef`, `holder-index` can look up all the `grain-id`s and those `grain`s can then be returned.

This runs into a problem when `grain`s can change `holder`s but keep the same `grain-id`. A subscriber to `/holder/0xdead.beef` will continue to hear about changes to the NFT grain `0xcafe.babe` even after `0xcafe.babe` has been traded to someone else.

To solve this problem, we added a filter. First, query the `holder-index` and get all those `grain`s that at one time were held by `0xdead.beef`. Second, check each of those `grain`s to see if they still have `=(0xdead.beef holder.p.grain)`.

This introduces a second problem: apps subscribes to `/holder/0xdead.beef` will stop hearing updates about `0xcafe.babe` once it has been traded away. There needs to be some indication that `0xcafe.babe` is no longer held by `/holder/0xdead.beef`.

This PR solves this problem by sending one final update about `0xcafe.babe`. Then the app must check that the `holder` field has not changed, and if it has changed, must update its own state to indicate that that grain is no longer held by `0xdead.beef`.

An alternative model is used in the `%wallet` in PR #161, where a subscription is instead made to the `%indexer` at `/batch-order`. Whenever a new batch comes in, the `%wallet` scries `/newest/holder` and processes the grains. Using this method it is clear what the state is from each query.