### PR TITLE
indexer: hack zigs `interface` to agree with mill zigs %give output

### DIFF
--- a/lib/zig/contracts/lib/zigs-interface-types.hoon
+++ b/lib/zig/contracts/lib/zigs-interface-types.hoon
@@ -46,10 +46,10 @@
   ~
   ::
   ++  give-cord
+    ::  TODO: add back in `{"budget": "ud"},` field
     ^-  cord
     '''
     [
-      {"budget": "ud"},
       {"to": "ux"},
       {"amount": "ud"},
       {"from-account": "ux"},


### PR DESCRIPTION
`mill` currently gives back zigs `%give` transactions to the chain without the `budget` field. This will be fixed Soon, but until then, hack the zigs `%give` interface to agree with the current output.

```json 
               "0x61.7461.6461.7465.6d2d.7367.697a": {
                  "label": "token-metadata",
                  "salt": 1936157050,
                  "lord": "0x74.6361.7274.6e6f.632d.7367.697a",
                  "data": {
                    "token-metadata": {
                      "name": "UQ| Tokens",
                      "salt": "0x7367.697a",
                      "deployer-address": "0x0",
                      "decimals": 18,
                      "cap": null,
                      "minters": null,
                      "symbol": "ZIG",
                      "supply": 1e+26,
                      "mintable": false
                    }
                  },
                  "id": "0x61.7461.6461.7465.6d2d.7367.697a",
                  "is-rice": true,
                  "holder": "0x74.6361.7274.6e6f.632d.7367.697a",
                  "town-id": "0x0"
                },
                "0x222f.e9fd.ba8c.98ee.79f3.a2b6.2088.f319.2235.957f.807e.6a86.75e4.e095.1b08.6a03": {
                  "label": "account",
                  "salt": 1936157050,
                  "lord": "0x74.6361.7274.6e6f.632d.7367.697a",
                  "data": {
                    "account": {
                      "balance": 1e+20,
                      "metadata": "0x61.7461.6461.7465.6d2d.7367.697a",
                      "nonce": 0,
                      "allowances": {}
                    }
                  },
                  "id": "0x222f.e9fd.ba8c.98ee.79f3.a2b6.2088.f319.2235.957f.807e.6a86.75e4.e095.1b08.6a03",
                  "is-rice": true,
                  "holder": "0x25a8.eb63.a5e7.3111.c173.639b.68ce.091d.d3fc.f139",
                  "town-id": "0x0"
                },
```