### PR TITLE
swap shag to sham

### DIFF
--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -387,8 +387,6 @@
     ?:  ?=(%kick -.sign)
       :_  this  ::  attempt to re-sub
       (watch-for-batches our.bowl 0x0)
-    ?:  ?=(%watch-ack -.sign)  (on-agent:def wire sign)
-    ?.  ?=(%fact -.sign)       (on-agent:def wire sign)
     ::  new batch -- scry to indexer for latest tokens and nfts held
     =/  addrs=(list address:smart)  ~(tap in ~(key by keys))
     =/  new-tokens

--- a/lib/merk.hoon
+++ b/lib/merk.hoon
@@ -10,16 +10,7 @@
 ++  shag                                                ::  256bit noun hash
   |=  yux=*  ^-  hash
   ::  TODO: make LRU-cache-optimized version for granary retrivial & modification
-  ?@  yux
-    (hash:pedersen yux 0)
-  ::
-  ::  NB:  first option here is more correct, but leads
-  ::  to extremely long hashing times for large nouns.
-  ::  second is a ~30x speedup on hashing contract nocks.
-  ::  TODO: jet +shag
-  ::
-  ::  (hash:pedersen $(yux -.yux) $(yux +.yux))
-  (hash:pedersen (jam yux) 0)
+  `@ux`(sham yux)
 ::
 ::  +sore: single sha-256 hash in ascending order, uses +dor as
 ::  fallback

--- a/lib/zig/sys/smart.hoon
+++ b/lib/zig/sys/smart.hoon
@@ -309,11 +309,14 @@
   ?:(=(~ a) & (apt:(bi key value) a))
 ::
 ++  shag                                                ::  256bit noun hash
-  |=  yux=*  ^-  hash
+  |=  yux=*
+  ~>  %shag.+<
+  ^-  hash
+  `@ux`(sham yux)
   ::  TODO: make LRU-cache-optimized version for granary retrivial & modification
-  ?@  yux
-    (hash:pedersen yux 0)
-  (hash:pedersen $(yux -.yux) $(yux +.yux))
+  ::  ?@  yux
+  ::    (hash:pedersen yux 0)
+  ::  (hash:pedersen $(yux -.yux) $(yux +.yux))
 ::
 ::  +sore: single Pedersen hash in ascending order, uses +dor as
 ::  fallback

--- a/lib/zink/zink.hoon
+++ b/lib/zink/zink.hoon
@@ -1,5 +1,5 @@
 /-  *zink
-/+  *zink-pedersen, *zink-json
+/+  *zink-pedersen, *zink-json, merk
 =>  |%
     +$  good      (unit *)
     +$  fail      (list [@ta *])
@@ -499,6 +499,9 @@
         %pedersen-hash
       ?.  ?=([@ @] sam)  %|^trace
       %&^(some (hash:pedersen sam))
+    ::
+        %shag
+      %&^(some (shag:merk sam))
     ==
   ::
   ++  frag

--- a/sur/zink.hoon
+++ b/sur/zink.hoon
@@ -72,5 +72,6 @@
       [%need 1]
       [%scot 5]
       [%pedersen-hash 10]
+      [%shag 1.000]
     ==
 --


### PR DESCRIPTION
Using SHA hashing instead of the very slow Pedersen hash in order to make execution-only testnet operable in a performant way with no extra jets.