### PR TITLE
wallet: sign as scry

### DIFF
--- a/app/uqbar.hoon
+++ b/app/uqbar.hoon
@@ -71,20 +71,23 @@
     |=  =path
     |^  ^-  (quip card _this)
     ?>  =(src.bowl our.bowl)
-    :_  this
     ?+    -.path  !!
-        %track  ~
+        %track  `this
         %wallet
-      ::  must be of the form, e.g.,
-      ::   /wallet/[requesting-app-name]/[*-updates]
-      ?.  ?=([%wallet @ @ ~] path)  ~
+      ?.  ?=([%wallet @ @ ~] path)
+        ~|  "%uqbar: wallet subscriptions must be of form:"
+        ~|  " /wallet/[requesting-app-name]/[*-updates]"
+        !!
+      :_  this
       (watch-wallet /[i.path]/[i.t.path] t.t.path)
     ::
         %indexer
-      ::  must be of the form, e.g.,
-      ::   /indexer/[requesting-app-name]/grain/[town-id]/[grain-id]
-      ?.  ?=([%indexer @ @ ^] path)  ~
+      ?.  ?=([%indexer @ @ ^] path)
+        ~|  "%uqbar: indexer subscriptions must be of form:"
+        ~|  " /indexer/[requesting-app-name]/grain/[town-id]/[grain-id]"
+        !!
       =/  town-id=id:smart  (slav %ux i.t.t.t.path)
+      :_  this
       (watch-indexer town-id /[i.path]/[i.t.path] t.t.path)
     ==
     ::
@@ -298,7 +301,7 @@
         [cards this]
       ==
     ::
-        %indexer
+        ?(%indexer %wallet)
       ?+  -.sign  (on-agent:def wire sign)
         %kick  [rejoin this]
         %fact  [[(pass-through cage.sign)]~ this]

--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -20,7 +20,7 @@
       ::  we track the nonce of each address we're handling
       ::  TODO: introduce a poke to check nonce from chain and re-align
       nonces=(map address:smart (map town=@ux nonce=@ud))
-      ::  signatures tracks any signed calls we've made
+      ::  TODO: remove signatures in state-1
       signatures=(list [=typed-message:smart =sig:smart])
       ::  tokens tracked for each address we're handling
       tokens=(map address:smart =book)
@@ -111,7 +111,6 @@
       ::  for now treat this as a nuke of the wallet
       %=  state
         nonces             ~
-        signatures         ~
         tokens             ~
         metadata-store     ~
         pending-store      ~
@@ -137,7 +136,6 @@
       ::  for now treat this as a nuke of the wallet
       %=  state
         nonces             ~
-        signatures         ~
         tokens             ~
         metadata-store     ~
         pending-store      ~
@@ -185,17 +183,6 @@
         %edit-nickname
       =+  -:(~(got by keys.state) address.act)
       `state(keys (~(put by keys) address.act [- nick.act]))
-    ::
-        %sign-typed-message
-      =/  keypair  (~(got by keys.state) from.act)
-      =/  hash     (sham typed-message.act)
-      =/  signature
-        ?~  priv.keypair
-          !!  ::  put it into some temporary thing for cold storage. Make it pending
-        %+  ecdsa-raw-sign:secp256k1:secp:crypto
-          hash
-        u.priv.keypair
-      `state(signatures [[typed-message.act signature] signatures])
     ::
         %set-nonce  ::  for testing/debugging
       =+  acc=(~(gut by nonces.state) address.act ~)
@@ -541,9 +528,6 @@
     |=  [hash=@ux [t=egg:smart action=supported-actions]]
     (parse-transaction:wallet-parsing hash t action)
   ::
-      [%signatures ~]
-    ``noun+!>(signatures.state)
-  ::
       [%pending @ ~]
     ::  return pending store for given pubkey
     =/  pub  (slav %ux i.t.t.path)
@@ -568,24 +552,10 @@
     =/  from=id:smart  (slav %ux i.t.t.path)
     =/  message=@      (slav %ud i.t.t.t.path)
     =/  keypair  (~(got by keys.state) from)
-    ?~  priv.keypair
-      !!  ::  put it into some temporary thing for cold storage. Make it pending
+    ?~  priv.keypair  !!
     :^  ~  ~  %noun
     !>  ^-  sig:smart
     %+  ecdsa-raw-sign:secp256k1:secp:crypto  message
-    u.priv.keypair
-  ::
-      [%sign-typed-message @ @ ~]
-    =/  from=id:smart  (slav %ux i.t.t.path)
-    =/  =typed-message:smart
-      ;;(typed-message:smart (cue (slav %ud i.t.t.t.path)))
-    =/  keypair  (~(got by keys.state) from)
-    =/  hash     (sham typed-message)
-    ?~  priv.keypair
-      !!  ::  put it into some temporary thing for cold storage. Make it pending
-    :^  ~  ~  %noun
-    !>  ^-  sig:smart
-    %+  ecdsa-raw-sign:secp256k1:secp:crypto  hash
     u.priv.keypair
   ==
 ::

--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -565,8 +565,8 @@
     ``noun+!>(`(map @ux [egg:smart supported-actions])`our)
   ::
       [%sign-message @ @ ~]
-    =/  from=id:smart  (slav %ux i.t.path)
-    =/  message=@      (slav %ud i.t.t.path)
+    =/  from=id:smart  (slav %ux i.t.t.path)
+    =/  message=@      (slav %ud i.t.t.t.path)
     =/  keypair  (~(got by keys.state) from)
     ?~  priv.keypair
       !!  ::  put it into some temporary thing for cold storage. Make it pending
@@ -576,9 +576,9 @@
     u.priv.keypair
   ::
       [%sign-typed-message @ @ ~]
-    =/  from=id:smart  (slav %ux i.t.path)
+    =/  from=id:smart  (slav %ux i.t.t.path)
     =/  =typed-message:smart
-      ;;(typed-message:smart (cue (slav %ud i.t.t.path)))
+      ;;(typed-message:smart (cue (slav %ud i.t.t.t.path)))
     =/  keypair  (~(got by keys.state) from)
     =/  hash     (sham typed-message)
     ?~  priv.keypair

--- a/app/wallet.hoon
+++ b/app/wallet.hoon
@@ -563,6 +563,30 @@
       (~(gut by pending-store) pub ~)
     ::
     ``noun+!>(`(map @ux [egg:smart supported-actions])`our)
+  ::
+      [%sign-message @ @ ~]
+    =/  from=id:smart  (slav %ux i.t.path)
+    =/  message=@      (slav %ud i.t.t.path)
+    =/  keypair  (~(got by keys.state) from)
+    ?~  priv.keypair
+      !!  ::  put it into some temporary thing for cold storage. Make it pending
+    :^  ~  ~  %noun
+    !>  ^-  sig:smart
+    %+  ecdsa-raw-sign:secp256k1:secp:crypto  message
+    u.priv.keypair
+  ::
+      [%sign-typed-message @ @ ~]
+    =/  from=id:smart  (slav %ux i.t.path)
+    =/  =typed-message:smart
+      ;;(typed-message:smart (cue (slav %ud i.t.t.path)))
+    =/  keypair  (~(got by keys.state) from)
+    =/  hash     (sham typed-message)
+    ?~  priv.keypair
+      !!  ::  put it into some temporary thing for cold storage. Make it pending
+    :^  ~  ~  %noun
+    !>  ^-  sig:smart
+    %+  ecdsa-raw-sign:secp256k1:secp:crypto  hash
+    u.priv.keypair
   ==
 ::
 ++  on-leave  on-leave:def

--- a/sur/wallet.hoon
+++ b/sur/wallet.hoon
@@ -64,7 +64,6 @@
       [%derive-new-address hdpath=tape nick=@t]
       [%delete-address address=@ux]
       [%edit-nickname address=@ux nick=@t]
-      [%sign-typed-message from=id:smart =typed-message:smart]
       [%add-tracked-address address=@ux nick=@t]
       ::  testing and internal
       [%set-nonce address=@ux town=id:smart new=@ud]


### PR DESCRIPTION
I think this is a way better interface for signing messages using keys stored in the wallet. I'm using this functionality in a subscription-gating project over [here](https://github.com/hosted-fornet/whitelist/pull/3). I like the `%sign-message` path best, but left the other in as well in case there is something I was missing about why typed messages are so special -- it seems to me that the serialization of the message should be up to the user, not the wallet to decide.

What do you think? @dr-frmr @tadad 

For reference, the previous way to do this is a poke [here](https://github.com/uqbar-dao/ziggurat/blob/cd771fb1b79acbccb9c4ae0a62daed8e83bc8088/app/wallet.hoon#L189-L202), followed by a scry to look at `signatures` stored in state. Unless there is some reason to keep the signatures around, this poke should be removed.