### PR TITLE
indexer: fix batch-order subs

### DIFF
--- a/app/indexer.hoon
+++ b/app/indexer.hoon
@@ -1447,7 +1447,7 @@
     |=  [ship sub-path=path]
     ^-  (unit [@tas path])
     ?~  sub-path  ~
-    ?.  ?=  ?(%grain %hash %holder %id %json %lord %town)
+    ?.  ?=  ?(%batch-order %grain %hash %holder %id %json %lord %town)
         i.sub-path
       ~
     `[`@tas`i.sub-path t.sub-path]
@@ -1461,25 +1461,27 @@
     |^
     =/  out
       %+  roll
-        ^-  (list ?(%id %json query-type:ui))
-        ~[%grain %hash %holder %id %json %lord %town]
-      |=  $:  query-type=?(%id %json query-type:ui)
+        ^-  (list ?(%batch-order %id %json query-type:ui))
+        :~  %batch-order
+            %grain
+            %hash
+            %holder
+            %id
+            %json
+            %lord
+            %town
+        ==
+      |=  $:  query-type=?(%batch-order %id %json query-type:ui)
               out=[cards=(list (list card)) paths=(list (list [path @ux])) updates=(list (list [@ux update:ui]))]
           ==
       =/  sub-cards  (make-sub-cards query-type)
       :+  [cards.sub-cards cards.out]
         [paths.sub-cards paths.out]
       [updates.sub-cards updates.out]
-    :_  [(zing paths.out) (zing updates.out)]
-    :-  %+  fact:io
-          :-  %indexer-update
-          !>(`update:ui`[%batch-order ~[root]])
-        %+  expand-paths  %history
-        ~[/batch-order/(scot %ux town-id)]
-    (zing cards.out)
+    [(zing cards.out) (zing paths.out) (zing updates.out)]
     ::
     ++  make-sub-cards
-      |=  query-type=?(%id %json query-type:ui)
+      |=  query-type=?(%batch-order %id %json query-type:ui)
       ^-  $:  cards=(list card)
               paths=(list [path @ux])
               updates=(list [@ux update:ui])
@@ -1504,9 +1506,12 @@
         [(slav %ux i.sub-path) (slav %ux i.t.sub-path)]
       =/  =update:ui
         ?+    query-type  !!
-            %hash    (get-hashes payload %.y %.n)
-            %holder  (serve-update query-type payload %.y %.n)
-            %id      (get-ids payload %.y)
+            %batch-order  [%batch-order ~[root]]
+            %hash         (get-hashes payload %.y %.n)
+            %id           (get-ids payload %.y)
+            %holder
+          (serve-update query-type payload %.y %.n)
+        ::
             ?(%grain %lord %town)
           (serve-update query-type payload %.y %.y)
         ==


### PR DESCRIPTION
Fix bug introduced in PR #170 for `/batch-order` subs. That PR added a new requirement for subscriptions: that a random string be appended to subscription paths (though `/history` is the trumping appendend, i.e. the last element). However, `/batch-order` subscriptions had been treated as a special case in the code, and were not properly updated to the new system, so that subscription updates would be incorrectly served to, e.g., `/batch-order/0x0` rather than `/batch-order/0x0/0xdead.beef`.

The present PR handles `/batch-order` subscriptions the same way as others so that the subscriptions are served to the properly disambiguated paths.

To test, send a tx from a fakeship. On master, the wallet balance (viewed via `:wallet +dbug`) will not update, but here it will.