### PR TITLE
indexer: remove state transition logic

### DIFF
--- a/app/indexer.hoon
+++ b/app/indexer.hoon
@@ -173,7 +173,7 @@
 +$  card  card:agent:gall
 --
 ::
-=|  inflated-state-2:ui
+=|  inflated-state-0:ui
 =*  state  -
 ::
 %-  agent:dbug
@@ -930,36 +930,6 @@
   =+  !<(=versioned-state:ui state-vase)
   ?-    -.versioned-state
       %0
-    ::  TODO: remove hardcode
-    =/  catchup-indexer-host=@p  ~dister-dozzod-bacdun
-    =/  catchup-indexer-dock=dock
-      [catchup-indexer-host %indexer]
-    :_  %-  inflate-state
-        ~(tap by batches-by-town.versioned-state)
-    :*  %2
-        batches-by-town.versioned-state
-        capitol.versioned-state
-        sequencer-update-queue.versioned-state
-        town-update-queue.versioned-state
-        ~
-        ~
-        catchup-indexer-dock
-    ==
-  ::
-      %1
-    :_  %-  inflate-state
-        ~(tap by batches-by-town.versioned-state)
-    :*  %2
-        batches-by-town.versioned-state
-        capitol.versioned-state
-        sequencer-update-queue.versioned-state
-        town-update-queue.versioned-state
-        ~
-        ~
-        catchup-indexer.versioned-state
-    ==
-  ::
-      %2
     :_  %-  inflate-state
         ~(tap by batches-by-town.versioned-state)
     %=  versioned-state

--- a/sur/indexer.hoon
+++ b/sur/indexer.hoon
@@ -60,13 +60,11 @@
   (map town-id=@ux (map batch-id=@ux batch))
 ::
 +$  versioned-state
-  $%  base-state-2
-      base-state-1
-      base-state-0
+  $%  base-state-0
   ==
 ::
-+$  base-state-2
-  $:  %2
++$  base-state-0
+  $:  %0
       =batches-by-town
       =capitol:seq
       =sequencer-update-queue
@@ -74,23 +72,6 @@
       old-sub-paths=(map path @ux)
       old-sub-updates=(map @ux update)
       catchup-indexer=dock
-  ==
-+$  base-state-1
-  $:  %1
-      =batches-by-town
-      =capitol:seq
-      =sequencer-update-queue
-      =town-update-queue
-      old-sub-updates=(map path update)
-      catchup-indexer=dock
-  ==
-+$  base-state-0
-  $:  %0
-      =batches-by-town
-      =capitol:seq
-      =sequencer-update-queue
-      =town-update-queue
-      old-sub-updates=(map path update)
   ==
 ::
 +$  indices-0
@@ -104,8 +85,6 @@
       =newest-batch-by-town
   ==
 ::
-+$  inflated-state-2  [base-state-2 indices-0]
-+$  inflated-state-1  [base-state-1 indices-0]
 +$  inflated-state-0  [base-state-0 indices-0]
 ::
 +$  batch-update-value


### PR DESCRIPTION
Remove state transition logic from %indexer since we are going to make a new testnet with breaking changes.

Another PR will remove the majority of the subscription logic from %indexer, and may also alter the state, since `old-sub-updates` and `old-sub-paths` will no longer be needed for tracking subscription diffs. I'll try to have that included in the breaking changes -- if I can't get it done in time, it will be the new `state-1`.