### PR TITLE
indexer: rip out subscription logic

### DIFF
--- a/app/uqbar.hoon
+++ b/app/uqbar.hoon
@@ -77,14 +77,20 @@
         %wallet
       ::  must be of the form, e.g.,
       ::   /wallet/[requesting-app-name]/[*-updates]
-      ?.  ?=([%wallet @ @ ~] path)  ~
+      ?.  ?=([%wallet @ @ ~] path)  ~  ::  TODO: kick
       (watch-wallet /[i.path]/[i.t.path] t.t.path)
     ::
         %indexer
       ::  must be of the form, e.g.,
-      ::   /indexer/[requesting-app-name]/grain/[town-id]/[grain-id]
-      ?.  ?=([%indexer @ @ ^] path)  ~
-      =/  town-id=id:smart  (slav %ux i.t.t.t.path)
+      ::   /indexer/[requesting-app-name]/batch-order/[town-id]
+      ::   or
+      ::   /indexer/[requesting-app-name]/json/batch-order/[town-id]
+      ?.  ?=([%indexer @ @ *] path)  ~  ::  TODO: kick
+      =/  town-id=id:smart              ::  TODO: generalize?
+        ?:  ?=([%indexer @ @ @ ~] path)
+          (slav %ux i.t.t.t.path)
+        ?>  ?=([%indexer @ %json @ @ ~] path)
+        (slav %ux i.t.t.t.t.path)
       (watch-indexer town-id /[i.path]/[i.t.path] t.t.path)
     ==
     ::
@@ -103,13 +109,9 @@
         ~&  >>>  " do not have indexer source for town {<town-id>}."
         ~&  >>>  " Add indexer source for town and try again."
         ~
-      =/  disambiguator=@ta  (scot %ux (cut 5 [0 1] eny.bowl))
       :_  ~
       %+  ~(watch pass:io (weld wire-prefix sub-path))
-        p.u.source
-      ?.  ?=(%history (rear sub-path))
-        (snoc sub-path disambiguator)
-      (snoc (snoc (snip sub-path) disambiguator) %history)
+      p.u.source  sub-path
     --
   ::
   ++  on-poke
@@ -182,8 +184,7 @@
         ==
       ::
           %set-sources
-        =/  p=path
-          /capitol-updates/[(scot %ux (cut 5 [0 1] eny.bowl))]
+        =/  p=path  /capitol-updates
         :-  :-  %-  ~(poke-self pass:io /ping-action-poke)
                 [%uqbar-action !>(`action:u`[%ping ~])]
             %+  murn  towns.act

--- a/sur/indexer.hoon
+++ b/sur/indexer.hoon
@@ -69,8 +69,6 @@
       =capitol:seq
       =sequencer-update-queue
       =town-update-queue
-      old-sub-paths=(map path @ux)
-      old-sub-updates=(map @ux update)
       catchup-indexer=dock
   ==
 ::


### PR DESCRIPTION
Rip out subcription logic from %indexer. Update %wallet to avoid using `/id` subscription path -- which no longer exists.

`/batch-order/[town-id]` (or `/json/batch-order/[town-id]`) is now main subscription path. `/batch-order` DOES reply on watch with entire `batch-order` history. New model is to subscribe to `/batch-order`, and when receive a %fact, scry for the data you need in the new batch.

Please take a look in particular at %wallet changes: I am less familiar with this code. I tried to keep functionality the same while moving to the new model.

FYI @willbach @0x70b1a5 : you will have to update the frontend if you were relying on subscriptions other than `/batch-order` / `/json/batch-order`. Happy to help here.