### PR TITLE
Da/pyro

### DIFF
--- a/app/pyro.hoon
+++ b/app/pyro.hoon
@@ -1,10 +1,11 @@
 ::  An ~~inferno~~ of virtual ships.  Put in some fish and watch them!
 ::
 ::  usage:
-::  |start %pyro
+::  |start %zig %pyro
 ::  :pyro +solid %base %zig
 ::  swap files is NOT working
 ::  :pyro &aqua-events [%init-ship ~dev %.y]~
+::  :pyro &action [%dojo ~dev "(add 2 2)"]
 ::
 ::  Then try stuff:
 ::  XX :aqua [%init ~[~bud ~dev]]
@@ -18,7 +19,7 @@
 ::
 ::  We get ++unix-event and ++pill from /-aquarium
 ::
-/-  *aquarium, *pyro
+/-  *pyro
 /+  pill, default-agent, naive, dbug, verb
 =,  pill-lib=pill
 =>  $~  |%
@@ -30,7 +31,7 @@
           pil=$>(%pill pill)  ::  the boot sequence a new fakeship will use
           assembled=*
           tym=@da  ::  a fake time, starting at *@da and manually ticked up
-          fresh-piers=(map [=ship fake=?] [=pier boths=(list unix-both)])
+          fresh-piers=(map =ship [=pier boths=(list unix-both)])
           fleet-snaps=(map term fleet)
           piers=fleet
       ==
@@ -84,7 +85,6 @@
         %pill         (poke-pill:ac !<(pill vase))
         %noun         (poke-noun:ac !<(* vase))
         %action       (handle-action !<(pyro-action vase))
-        ::  %azimuth-action
       ==
     [cards this]
     ::
@@ -171,17 +171,15 @@
   ::  store post-pill ship for later re-use
   ::
   ++  ahoy
-    |=  fake=?
-    =?  fresh-piers  !(~(has by fresh-piers) [who fake])
-      %+  ~(put by fresh-piers)  [who fake]
+    =?  fresh-piers  !(~(has by fresh-piers) who)
+      %+  ~(put by fresh-piers)  who
       [pier-data (~(get ja unix-boths) who)]
     ..ahoy
   ::
   ::  restore post-pill ship for re-use
   ::
   ++  yaho
-    |=  fake=?
-    =/  fresh  (~(got by fresh-piers) [who fake])
+    =/  fresh  (~(got by fresh-piers) who)
     =.  pier-data  pier.fresh
     =.  boths.fresh  (flop boths.fresh)
     |-
@@ -517,12 +515,10 @@
   ?-  -.ae
   ::
       %init-ship
-    ?:  &(fake.ae (~(has by fresh-piers) [who fake]:ae))
+    ?:  (~(has by fresh-piers) who:ae)
       ~&  [%aqua %cached-init +.ae]
-      =.  this  abet-pe:(yaho fake):[ae (pe who.ae)]
-      ?:  fake.ae  (pe who.ae)
-      ::  %pyro only handles fake ships
-      !!
+      =.  this  abet-pe:yaho:[ae (pe who.ae)]
+      (pe who.ae)
     =.  this  abet-pe:(publish-effect:(pe who.ae) [/ %sleep ~])
     =/  initted
       =<  plow
@@ -547,9 +543,7 @@
         ::
         :_  ~
         :^  /d/term/1  %boot  &
-        ?:  fake.ae
-          [%fake who.ae]
-        !!  ::  %pyro only handles fakeships
+        [%fake who.ae]
         ::
         userspace-ova.pil  :: load os
         ::
@@ -559,14 +553,11 @@
             [/e/http-server/0v1n.2m9vh %live 8.080 `8.445]
             [/a/newt/0v1n.2m9vh %born ~]
             [/d/term/1 %hail ~]
-          ::
-            ?:  fake.ae  ~
-            =+  [%raw-poke %noun %refresh-rate ~s30]
-            [/g/aqua/reduce-refresh-rate %deal [. .]:who.ae %azimuth -]~
+            ~
         ==
       ==
     =.  this
-      abet-pe:(ahoy fake):[ae initted]
+      abet-pe:ahoy:[ae initted]
     (pe who.ae)
   ::
       %pause-events

--- a/app/pyro.hoon
+++ b/app/pyro.hoon
@@ -4,8 +4,8 @@
 ::  |start %zig %pyro
 ::  :pyro +solid %base %zig
 ::  swap files is NOT working
-::  :pyro &aqua-events [%init-ship ~dev %.y]~
-::  :pyro &action [%dojo ~dev "(add 2 2)"]
+::  :pyro &aqua-events [%init-ship ~dev %.y]~  OR  :pyro|init ~dev
+::  :pyro &action [%dojo ~dev "(add 2 2)"]     OR  :pyro|dojo ~dev "(add 2 2)"
 ::
 ::  Then try stuff:
 ::  XX :aqua [%init ~[~bud ~dev]]
@@ -17,7 +17,7 @@
 ::  XX :aqua [%file ~[~bud ~dev] %/sys/vane]
 ::  XX :aqua [%pause-events ~[~bud ~dev]]
 ::
-::  We get ++unix-event and ++pill from /-aquarium
+::  We get ++unix-event and ++pill from /-pyro
 ::
 /-  *pyro
 /+  pill, default-agent, naive, dbug, verb
@@ -126,7 +126,25 @@
       !!
     `this
   ::
-  ++  on-peek   peek:ac
+  ++  on-peek
+    |=  =path
+    ^-  (unit (unit cage))
+    ?+  path  ~
+        [%x %fleet-snap @ ~]  ``noun+!>((~(has by fleet-snaps) i.t.t.path))
+        [%x %fleets ~]        ``noun+!>((turn ~(tap by fleet-snaps) head))
+        [%x %ships ~]         ``noun+!>((turn ~(tap by ships.piers) head))
+        [%x %pill ~]          ``pill+!>(pil)
+        [%x %i @ @ @ @ @ *]
+      ::   ship | scry path
+      ::          care, ship, desk, time, path
+      ::  scry into running virtual ships
+      =/  who  (slav %p i.t.t.path)
+      =/  pier  (~(get by ships.piers) who)
+      ?~  pier
+        ~
+      :^  ~  ~  %noun  !>
+      (peek:(pe who) t.t.t.path)
+    ==
   ++  on-leave  on-leave:def
   ++  on-agent  on-agent:def
   ++  on-arvo   on-arvo:def
@@ -640,25 +658,6 @@
 ::
 ::  Check whether we have a snapshot
 ::
-++  peek
-  |=  =path
-  ^-  (unit (unit cage))
-  ?+  path  ~
-      [%x %fleet-snap @ ~]  ``noun+!>((~(has by fleet-snaps) i.t.t.path))
-      [%x %fleets ~]        ``noun+!>((turn ~(tap by fleet-snaps) head))
-      [%x %ships ~]         ``noun+!>((turn ~(tap by ships.piers) head))
-      [%x %pill ~]          ``pill+!>(pil)
-      [%x %i @ @ @ @ @ *]
-    ::   ship | scry path
-    ::          care, ship, desk, time, path
-    ::  scry into running virtual ships
-    =/  who  (slav %p i.t.t.path)
-    =/  pier  (~(get by ships.piers) who)
-    ?~  pier
-      ~
-    :^  ~  ~  %noun  !>
-    (peek:(pe who) t.t.t.path)
-  ==
 ::
 ::  Trivial scry for mock
 ::

--- a/app/pyro.hoon
+++ b/app/pyro.hoon
@@ -1,4 +1,4 @@
-::  An ~~inferno~~ of virtual ships.  Put in some fish and watch them!
+::  An ~~inferno~~ of virtual ships.  Put in some fish and watch them die!
 ::
 ::  usage:
 ::  |start %zig %pyro
@@ -39,7 +39,7 @@
     ::
     +$  pill  pill:pill-lib
     ::
-    +$  fleet  [ships=(map ship pier)]
+    +$  fleet  (map ship pier)
     +$  pier
       $:  snap=*
           event-log=(list unix-timed-event)
@@ -111,7 +111,7 @@
         [%event who.act ue]
       ::
           %remove-ship
-        =.  ships.piers  (~(del by ships.piers) who.act)
+        =.  piers  (~(del by piers) who.act)
         `state
       ==
     --
@@ -137,14 +137,14 @@
     ?+  path  ~
         [%x %fleet-snap @ ~]  ``noun+!>((~(has by fleet-snaps) i.t.t.path))
         [%x %fleets ~]        ``noun+!>((turn ~(tap by fleet-snaps) head))
-        [%x %ships ~]         ``noun+!>((turn ~(tap by ships.piers) head))
+        [%x %ships ~]         ``noun+!>((turn ~(tap by piers) head))
         [%x %pill ~]          ``pill+!>(pil)
         [%x %i @ @ @ @ @ *]
       ::   ship | scry path
       ::          care, ship, desk, time, path
       ::  scry into running virtual ships
       =/  who  (slav %p i.t.t.path)
-      =/  pier  (~(get by ships.piers) who)
+      =/  pier  (~(get by piers) who)
       ?~  pier
         ~
       :^  ~  ~  %noun  !>
@@ -170,7 +170,7 @@
 ::
 ++  pe
   |=  who=ship
-  =+  (~(gut by ships.piers) who *pier)
+  =+  (~(gut by piers) who *pier)
   =*  pier-data  -
   |%
   ::
@@ -178,7 +178,7 @@
   ::
   ++  abet-pe
     ^+  this
-    =.  ships.piers  (~(put by ships.piers) who pier-data)
+    =.  piers  (~(put by piers) who pier-data)
     this
   ::
   ::  Initialize new ship
@@ -414,7 +414,7 @@
 ++  plow-all
   |-  ^+  this
   =/  who
-    =/  pers  ~(tap by ships.piers)
+    =/  pers  ~(tap by piers)
     |-  ^-  (unit ship)
     ?~  pers
       ~
@@ -586,7 +586,7 @@
   ::
       %snap-ships
     =.  this
-      %+  turn-ships  (turn ~(tap by ships.piers) head)
+      %+  turn-ships  (turn ~(tap by piers) head)
       |=  [who=ship thus=_this]
       =.  this  thus
       (publish-effect:(pe who) [/ %kill ~])
@@ -596,7 +596,7 @@
       %+  murn  hers.ae
       |=  her=ship
       ^-  (unit (pair ship pier))
-      =+  per=(~(get by ships.piers) her)
+      =+  per=(~(get by piers) her)
       ?~  per
         ~
       `[her u.per]
@@ -606,14 +606,14 @@
   ::
       %restore-snap
     =.  this
-      %+  turn-ships  (turn ~(tap by ships.piers) head)
+      %+  turn-ships  (turn ~(tap by piers) head)
       |=  [who=ship thus=_this]
       =.  this  thus
       (publish-effect:(pe who) [/ %kill ~])
     =.  piers  (~(got by fleet-snaps) lab.ae)
     ::  =.  this   start-azimuth-timer
     =.  this
-      %+  turn-ships  (turn ~(tap by ships.piers) head)
+      %+  turn-ships  (turn ~(tap by piers) head)
       |=  [who=ship thus=_this]
       =.  this  thus
       (publish-effect:(pe who) [/ %restore ~])

--- a/app/pyro.hoon
+++ b/app/pyro.hoon
@@ -94,6 +94,7 @@
       ?-    -.act
           %peek
         !!
+      ::
           %dojo
         :_  state
         =-  [%pass /self-poke %agent [our.bowl %pyro] %poke -]~
@@ -108,6 +109,10 @@
           ==
         |=  ue=unix-event
         [%event who.act ue]
+      ::
+          %remove-ship
+        =.  ships.piers  (~(del by ships.piers) who.act)
+        `state
       ==
     --
   ::
@@ -164,8 +169,6 @@
 ::  Represents a single ship's state.
 ::
 ++  pe
-  ::NOTE  if we start needing the fake flag outside of +ahoy and +yaho,
-  ::      probably add it as an argument here.
   |=  who=ship
   =+  (~(gut by ships.piers) who *pier)
   =*  pier-data  -

--- a/gen/pyro/dojo.hoon
+++ b/gen/pyro/dojo.hoon
@@ -4,13 +4,5 @@
 =,  aquarium
 :-  %say
 |=  [* [her=ship command=tape ~] ~]
-:-  %aqua-events
-%+  turn
-  ^-  (list unix-event)
-  :~  [/d/term/1 %belt %ctl `@c`%e]
-      [/d/term/1 %belt %ctl `@c`%u]
-      [/d/term/1 %belt %txt ((list @c) command)]
-      [/d/term/1 %belt %ret ~]
-  ==
-|=  ue=unix-event
-[%event her ue]
+:-  %action
+[%dojo her command]

--- a/gen/pyro/dojo.hoon
+++ b/gen/pyro/dojo.hoon
@@ -1,7 +1,7 @@
 ::  Usage: :pyro|dojo ~dev "|start %zig %sequencer"
 ::
-/-  aquarium
-=,  aquarium
+/-  pyro
+=,  pyro
 :-  %say
 |=  [* [her=ship command=tape ~] ~]
 :-  %action

--- a/gen/pyro/init.hoon
+++ b/gen/pyro/init.hoon
@@ -5,4 +5,4 @@
 :-  %say
 |=  [* [her=ship ~] ~]
 :-  %aqua-events
-[%init-ship her &]~
+[%init-ship her]~

--- a/gen/pyro/init.hoon
+++ b/gen/pyro/init.hoon
@@ -1,7 +1,7 @@
 :: Start a pyro ship
 ::
-/-  aquarium
-=,  aquarium
+/-  pyro
+=,  pyro
 :-  %say
 |=  [* [her=ship ~] ~]
 :-  %aqua-events

--- a/gen/pyro/scry.hoon
+++ b/gen/pyro/scry.hoon
@@ -1,0 +1,17 @@
+::  Scry an agent inside of a pyro ship
+::  Usage: +zig!pyro/scry ~dev %sequencer /status/noun
+::
+/-  pyro
+=,  pyro
+:-  %say
+|=  [[now=@da * =beak] [her=ship app=@tas =path ~] ~]
+:-  %noun
+.^  noun
+    %gx
+    %+  weld
+      :~  (scot %p p.beak)  %pyro  (scot %da now)  ::  /=pyro=
+          %i  (scot %p her)  %gx                   ::  /i/~dev/gx
+          (scot %p her)  app  (scot %da *@da)      ::  /=sequencer=
+      ==
+    (weld path /noun)
+==

--- a/gen/pyro/scry.hoon
+++ b/gen/pyro/scry.hoon
@@ -6,12 +6,14 @@
 :-  %say
 |=  [[now=@da * =beak] [her=ship app=@tas =path ~] ~]
 :-  %noun
+::  XX have to ;; the result
 .^  noun
     %gx
-    %+  weld
-      :~  (scot %p p.beak)  %pyro  (scot %da now)  ::  /=pyro=
-          %i  (scot %p her)  %gx                   ::  /i/~dev/gx
-          (scot %p her)  app  (scot %da *@da)      ::  /=sequencer=
-      ==
-    (weld path /noun)
+    %-  zing
+    :~  /(scot %p p.beak)/pyro/(scot %da now)  ::  /=pyro=
+        /i/(scot %p her)/gx                    ::  /i/~dev/gx
+        /(scot %p her)/[app]/(scot %da *@da)   ::  /=sequencer=
+        path                                   ::  /status/noun
+        /noun                                  ::  /noun
+    ==
 ==

--- a/lib/py/io.hoon
+++ b/lib/py/io.hoon
@@ -1,4 +1,4 @@
-/-  *aquarium, spider
+/-  *pyro, spider
 /+  libstrand=strand, *strandio, util=py-util
 =,  strand=strand:libstrand
 |%
@@ -7,12 +7,6 @@
   =/  m  (strand ,~)
   ^-  form:m
   (poke-our %pyro %aqua-events !>(events))
-::
-++  send-azimuth-action
-  |=  =azimuth-action
-  =/  m  (strand ,~)
-  ^-  form:m
-  (poke-our %pyro %azimuth-action !>(azimuth-action))
 ::
 ++  take-unix-effect
   =/  m  (strand ,[ship unix-effect])
@@ -23,11 +17,6 @@
 ::
 ++  start-simple
   (start-test %aqua-ames %aqua-behn %aqua-dill %aqua-eyre ~)
-::
-++  start-azimuth
-  =/  m  (strand ,~)
-  ^-  form:m
-  ;<(~ bind:m start-simple init)
 ::
 ++  end
   (end-test %aqua-ames %aqua-behn %aqua-dill %aqua-eyre ~)
@@ -88,32 +77,12 @@
   ^-  form:m
   (pure:m ~)
 ::
-::
-++  init
-  =/  m  (strand ,~)
-  ^-  form:m
-  (send-azimuth-action %init-azimuth ~)
-::
-++  spawn
-  |=  =ship
-  ~&  >  "spawning {<ship>}"
-  =/  m  (strand ,~)
-  ^-  form:m
-  (send-azimuth-action %spawn ship)
-::
-++  breach
-  |=  =ship
-  ~&  >  "breaching {<ship>}"
-  =/  m  (strand ,~)
-  ^-  form:m
-  (send-azimuth-action %breach ship)
-::
 ++  init-ship
-  |=  [=ship fake=?]
+  |=  =ship
   =/  m  (strand ,~)
   ^-  form:m
   ~&  >  "starting {<ship>}"
-  ;<  ~  bind:m  (send-events (init:util ship fake))
+  ;<  ~  bind:m  (send-events (init:util ship))
   (check-ship-booted ship)
 ::
 ++  check-ship-booted

--- a/lib/py/util.hoon
+++ b/lib/py/util.hoon
@@ -68,6 +68,7 @@
       |=  =blit:dill
       ?.  ?=(%lin -.blit)
         |
+      ::  prints all ship output to the dojo ~&  >  (tufa p.blit) 
       !=(~ (find what p.blit))
   ==
 ::

--- a/lib/py/util.hoon
+++ b/lib/py/util.hoon
@@ -1,6 +1,6 @@
 ::  Utility functions for constructing tests
 ::
-/-  *aquarium
+/-  *pyro
 |%
 ::
 ::  Turn [ship (list unix-event)] into (list ph-event)
@@ -15,9 +15,9 @@
 ::  Start a ship (low-level; prefer +raw-ship)
 ::
 ++  init
-  |=  [who=ship fake=?]
+  |=  who=ship
   ^-  (list aqua-event)
-  [%init-ship who fake]~
+  [%init-ship who]~
 ::
 ::  Send dojo command
 ::

--- a/sur/pyro.hoon
+++ b/sur/pyro.hoon
@@ -1,6 +1,78 @@
+::  Traditionally, ovo refers to an ovum -- (pair wire card) -- and ova
+::  refers to a list of them.  We have several versions of each of these
+::  depending on context, so we do away with that naming scheme and use
+::  the following naming scheme.
+::
+::  Every card is either an `event` or an `effect`.  Prepended to this
+::  is `unix` if it has no ship associated with it, or `aqua` if it
+::  does.  `timed` is added if it includes the time of the event.
+::
+::  Short names are simply the first letter of each word plus `s` if
+::  it's a list.
+::
+/+  pill
+=,  pill-lib=pill
 |%
+++  ph-event
+  $%  [%test-done p=?]
+      aqua-event
+  ==
+::
++$  unix-event  ::NOTE  like unix-event:pill-lib but for all tasks
+  %+  pair  wire
+  $%  [%wack p=@]
+      [%what p=(list (pair path (cask)))]
+      [%whom p=ship]
+      [%boot ? $%($>(%fake task:jael) $>(%dawn task:jael))]
+      [%wyrd p=vere]
+      [%verb p=(unit ?)]
+      task-arvo
+  ==
++$  pill        pill:pill-lib
+::
++$  aqua-event
+  $%  [%init-ship who=ship]
+      [%pause-events who=ship]
+      [%snap-ships lab=term hers=(list ship)]
+      [%restore-snap lab=term]
+      [%event who=ship ue=unix-event]
+  ==
+::
 +$  pyro-action
   $%  [%dojo who=@p command=tape]
       [%peek =path]
+  ==
+::
++$  aqua-effects
+  [who=ship ufs=(list unix-effect)]
+::
++$  aqua-effect
+  [who=ship ufs=unix-effect]
+::
++$  aqua-events
+  [who=ship utes=(list unix-timed-event)]
+::
++$  aqua-boths
+  [who=ship ub=(list unix-both)]
+::
++$  unix-both
+  $%  [%event unix-timed-event]
+      [%effect unix-effect]
+  ==
+::
++$  unix-timed-event  [tym=@da ue=unix-event]
+::
++$  unix-effect
+  %+  pair  wire
+  $%  [%blit p=(list blit:dill)]
+      [%send p=lane:ames q=@]
+      [%doze p=(unit @da)]
+      [%thus p=@ud q=(unit hiss:eyre)]
+      [%ergo p=@tas q=mode:clay]
+      [%sleep ~]
+      [%restore ~]
+      [%kill ~]
+      [%init ~]
+      [%request id=@ud request=request:http]
   ==
 --

--- a/sur/pyro.hoon
+++ b/sur/pyro.hoon
@@ -41,6 +41,7 @@
 +$  pyro-action
   $%  [%dojo who=@p command=tape]
       [%peek =path]
+      [%remove-ship who=@p]
   ==
 ::
 +$  aqua-effects

--- a/ted/py/add.hoon
+++ b/ted/py/add.hoon
@@ -5,7 +5,7 @@
 |=  args=vase
 =/  m  (strand ,vase)
 ;<  ~  bind:m  start-simple
-;<  ~  bind:m  (init-ship ~dev &)
+;<  ~  bind:m  (init-ship ~dev)
 ;<  ~  bind:m  (dojo ~dev "(add 2 3)")
 ;<  ~  bind:m  (wait-for-output ~dev "5")
 ;<  ~  bind:m  (dojo ~dev ".^(@tas %gx /=sequencer=/status/noun)")


### PR DESCRIPTION
random cleanups I want merged before I start fixing `|commit`s
- no more `fake` flag for ships
- ripped out (almost?) all azimuth code
- some new useful generators like `+scry` which actually scries pyro ship's agent state
- `%remove-ship` added (the fresh pier remains cached so starting it back up is fast)
- random refactorings