### PR TITLE
Replace all instances of `shard` with `town`

### DIFF
--- a/app/batcher-interval.hoon
+++ b/app/batcher-interval.hoon
@@ -55,7 +55,7 @@
   :_  this
   :~  [%pass /batch-timer %arvo %b %wait wait]
       =-  [%pass /seq-poke %agent [our.bowl %sequencer] %poke -]
-      [%sequencer-shard-action !>(`shard-action:seq`[%trigger-batch ~])]
+      [%sequencer-town-action !>(`town-action:seq`[%trigger-batch ~])]
   ==
 ::
 ++  on-init   `this(state [%0 %.n ~m1])

--- a/app/batcher-threshold.hoon
+++ b/app/batcher-threshold.hoon
@@ -59,7 +59,7 @@
   :_  this
   :~  [%pass /batch-timer %arvo %b %wait wait]
       =-  [%pass /seq-poke %agent [our.bowl %sequencer] %poke -]
-      [%sequencer-shard-action !>(`shard-action:seq`[%trigger-batch ~])]
+      [%sequencer-town-action !>(`town-action:seq`[%trigger-batch ~])]
   ==
 ::
 ++  on-init   `this(state [%0 %.n 1])

--- a/app/faucet.hoon
+++ b/app/faucet.hoon
@@ -72,8 +72,8 @@
         ?:  =(%earl (clan:title src))
           (sein:title our now src)
         src
-      ?~  shard-info=(~(get by shard-infos) shard-id.action)
-        ~|("%faucet: invalid shard. Valid shards: {<~(key by shard-infos)>}" !!)
+      ?~  town-info=(~(get by town-infos) town-id.action)
+        ~|("%faucet: invalid town. Valid towns: {<~(key by town-infos)>}" !!)
       =/  [unlock=@da count=@ud]
         (~(gut by on-timeout) par [*@da 0])
       ?:  (gth unlock now)
@@ -88,16 +88,16 @@
           :-  %wallet-poke
           !>  ^-  wallet-poke:w
           :*  %transaction
-              from=address.u.shard-info
-              contract=zigs-contract.u.shard-info
-              shard=shard-id.action
+              from=address.u.town-info
+              contract=zigs-contract.u.town-info
+              town=town-id.action
               :^    %give
                   to=address.action
                 amount=volume
-              grain=zigs-account.u.shard-info
+              grain=zigs-account.u.town-info
           ==
         =-  [%pass /self-poke %agent [our.bowl %faucet] %poke -]
-        [%faucet-action !>(`action:f`[%confirm address.u.shard-info])]
+        [%faucet-action !>(`action:f`[%confirm address.u.town-info])]
       ~
     ::
         %confirm
@@ -127,11 +127,11 @@
         %edit-timeout-duration
       `this(timeout-duration timeout-duration.c)
     ::
-        %put-shard
+        %put-town
       :-  ~
       %=  this
-          shard-infos
-        (~(put by shard-infos) shard-id.c shard-info.c)
+          town-infos
+        (~(put by town-infos) town-id.c town-info.c)
       ==
     ==
   --

--- a/app/indexer.hoon
+++ b/app/indexer.hoon
@@ -14,9 +14,9 @@
 ::    A single argument is interpreted as the hash of the
 ::    queried item (e.g., for a `/item` query, the `item-id`).
 ::    For two arguments, the first is interpreted as the
-::    `shard-id` in which to query for the second, the item hash.
+::    `town-id` in which to query for the second, the item hash.
 ::    In other words, two arguments restricts the query to
-::    a shard, while one argument queries all indexed shards.
+::    a town, while one argument queries all indexed towns.
 ::
 ::    Scry paths may be prepended with a `/newest`, which
 ::    will return results only in the most recent batch.
@@ -42,41 +42,41 @@
 ::    is `/x/json/newest/holder/0xdead.beef`.
 ::
 ::    /x/batch/[batch-id=@ux]
-::    /x/batch/[shard-id=@ux]/[batch-id=@ux]:
+::    /x/batch/[town-id=@ux]/[batch-id=@ux]:
 ::      An entire batch.
-::    /x/batch-order/[shard-id=@ux]
-::    /x/batch-order/[shard-id=@ux]/[nth-most-recent=@ud]/[how-many=@ud]:
-::      The order of batches for a shard, or a subset thereof.
+::    /x/batch-order/[town-id=@ux]
+::    /x/batch-order/[town-id=@ux]/[nth-most-recent=@ud]/[how-many=@ud]:
+::      The order of batches for a town, or a subset thereof.
 ::    /x/txn/[txn-id=@ux]:
-::    /x/txn/[shard-id=@ux]/[txn-id=@ux]:
+::    /x/txn/[town-id=@ux]/[txn-id=@ux]:
 ::      Info about txn (transaction) with the given hash.
 ::    /x/from/[from-id=@ux]:
-::    /x/from/[shard-id=@ux]/[from-id=@ux]:
+::    /x/from/[town-id=@ux]/[from-id=@ux]:
 ::      History of sender with the given hash.
 ::    /x/item/[item-id=@ux]:
-::    /x/item/[shard-id=@ux]/[item-id=@ux]:
+::    /x/item/[town-id=@ux]/[item-id=@ux]:
 ::      Historical states of item with given hash.
 ::    :: /x/item-txns/[item-id=@ux]:  ::  TODO: reenable
-::    :: /x/item-txns/[shard-id=@ux]/[item-id=@ux]:
+::    :: /x/item-txns/[town-id=@ux]/[item-id=@ux]:
 ::    ::   txns involving item with given hash.
 ::    /x/hash/[hash=@ux]:
-::    /x/hash/[shard-id=@ux]/[hash=@ux]:
+::    /x/hash/[town-id=@ux]/[hash=@ux]:
 ::      Info about hash (queries all indexes for hash).
 ::    /x/holder/[holder-id=@ux]:
-::    /x/holder/[shard-id=@ux]/[holder-id=@ux]:
+::    /x/holder/[town-id=@ux]/[holder-id=@ux]:
 ::      items held by id with given hash.
 ::    /x/id/[id=@ux]:
-::    /x/id/[shard-id=@ux]/[id=@ux]:
+::    /x/id/[town-id=@ux]/[id=@ux]:
 ::      History of id (queries `from`s and `to`s).
 ::    /x/source/[source-id=@ux]:
-::    /x/source/[shard-id=@ux]/[source-id=@ux]:
+::    /x/source/[town-id=@ux]/[source-id=@ux]:
 ::      items ruled by source with given hash.
 ::    /x/to/[to-id=@ux]:
-::    /x/to/[shard-id=@ux]/[to-id=@ux]:
+::    /x/to/[town-id=@ux]/[to-id=@ux]:
 ::      History of receiver with the given hash.
-::    /x/shard/[shard-id=@ux]:
-::    /x/shard/[shard-id=@ux]/[shard-id=@ux]:
-::      History of shard: all batches.
+::    /x/town/[town-id=@ux]:
+::    /x/town/[town-id=@ux]/[town-id=@ux]:
+::      History of town: all batches.
 ::
 ::
 ::    ## Subscription paths
@@ -110,15 +110,15 @@
 ::    and `con/lib/*interface-types.hoon`
 ::    for examples.
 ::
-::    /batch-order/[shard-id=@ux]:
+::    /batch-order/[town-id=@ux]:
 ::      A stream of batch ids.
 ::    /item/[item-id=@ux]
-::    /item/[shard-id=@ux]/[item-id=@ux]:
+::    /item/[town-id=@ux]/[item-id=@ux]:
 ::      A stream of changes to given item.
 ::    /hash/[@ux]:
 ::      A stream of new activity of given id.
 ::    /holder/[holder-id=@ux]
-::    /holder/[shard-id=@ux]/[holder-id=@ux]:
+::    /holder/[town-id=@ux]/[holder-id=@ux]:
 ::      A stream of new activity of given holder.
 ::      If a held item changes holders, the final update
 ::      sent for that item will have the updated holder.
@@ -128,16 +128,16 @@
 ::      that item.
 ::      Reply on-watch is entire history of held items.
 ::    /id/[id=@ux]
-::    /id/[shard-id=@ux]/[id=@ux]:
+::    /id/[town-id=@ux]/[id=@ux]:
 ::      A stream of new transactions of given id:
 ::      specifically transactions where id appears
 ::      in the `from` or `contract` fields.
 ::    /source/[source-id=@ux]
-::    /source/[shard-id=@ux]/[source-id=@ux]:
+::    /source/[town-id=@ux]/[source-id=@ux]:
 ::      A stream of new activity of given source.
-::    /shard/[shard-id=@ux]
-::    /shard/[shard-id=@ux]/[shard-id=@ux]:
-::      A stream of each new batch for shard.
+::    /town/[town-id=@ux]
+::    /town/[town-id=@ux]/[town-id=@ux]:
+::      A stream of each new batch for town.
 ::
 ::
 ::    ##  Pokes
@@ -270,12 +270,12 @@
       indexer-bootstrap-path
     ::
         %indexer-catchup
-      =+  !<([=dock shard=id:smart root=id:smart] vase)
+      =+  !<([=dock town=id:smart root=id:smart] vase)
       :_  this(catchup-indexer dock)
       %^    set-watch-target:ic
-          (indexer-catchup-wire shard root)
+          (indexer-catchup-wire town root)
         dock
-      (indexer-catchup-path shard root)
+      (indexer-catchup-path town root)
     ==
   ::
   ++  on-watch
@@ -295,10 +295,10 @@
       !>(`versioned-state:ui`-.state)
     ::
         [%indexer-catchup @ @ ~]
-      =/  shard-id=id:smart  (slav %ux i.t.path)
+      =/  town-id=id:smart  (slav %ux i.t.path)
       =/  root=id:smart     (slav %ux i.t.t.path)
       =/  [=batches:ui =batch-order:ui]
-        (~(gut by batches-by-shard) shard-id [~ ~])
+        (~(gut by batches-by-town) town-id [~ ~])
       =.  batch-order  (flop batch-order)
       :_  this
       %-  fact-init-kick:io
@@ -327,7 +327,7 @@
             [%item @ @ %history ~]    [%item @ @ @ %history ~]
             [%holder @ @ %history ~]  [%holder @ @ @ %history ~]
             [%source @ @ %history ~]  [%source @ @ @ %history ~]
-            [%shard @ @ %history ~]   [%shard @ @ @ %history ~]
+            [%town @ @ %history ~]   [%town @ @ @ %history ~]
         ==
       :_  this
       :_  ~
@@ -356,7 +356,7 @@
             [%item @ @ ~]    [%item @ @ @ ~]
             [%holder @ @ ~]  [%holder @ @ @ ~]
             [%source @ @ ~]  [%source @ @ @ ~]
-            [%shard @ @ ~]   [%shard @ @ @ ~]
+            [%town @ @ ~]   [%town @ @ @ ~]
         ==
       `this
     ==
@@ -373,7 +373,7 @@
             [%id *]
             [%json *]
             [%source *]
-            [%shard *]
+            [%town *]
             [%capitol-updates *]
             [%indexer-bootstrap ~]
             [%indexer-catchup @ @ ~]
@@ -428,7 +428,7 @@
             [%holder @ ~]      [%holder @ @ ~]
             [%source @ ~]      [%source @ @ ~]
             [%to @ ~]          [%to @ @ ~]
-            [%shard @ ~]       [%shard @ @ ~]
+            [%town @ ~]       [%town @ @ ~]
         ==
       =/  =query-type:ui  ;;(query-type:ui i.args)
       =/  query-payload=(unit query-payload:ui)
@@ -443,17 +443,17 @@
       ==
     ::
         [%batch-order @ ~]
-      =/  shard-id=@ux  (slav %ux i.t.args)
+      =/  town-id=@ux  (slav %ux i.t.args)
       %-  make-peek-update
-      ?~  bs=(~(get by batches-by-shard) shard-id)  ~
+      ?~  bs=(~(get by batches-by-town) town-id)  ~
       [%batch-order batch-order.u.bs]
     ::
         [%batch-order @ @ @ ~]
-      =/  [shard-id=@ux nth-most-recent=@ud how-many=@ud]
+      =/  [town-id=@ux nth-most-recent=@ud how-many=@ud]
         :+  (slav %ux i.t.args)  (slav %ud i.t.t.args)
         (slav %ud i.t.t.t.args)
       %-  make-peek-update
-      ?~  bs=(~(get by batches-by-shard) shard-id)  ~
+      ?~  bs=(~(get by batches-by-town) town-id)  ~
       :-  %batch-order
       (swag [nth-most-recent how-many] batch-order.u.bs)
     ==
@@ -516,10 +516,10 @@
         ::   automagically `+on-load`, but not here.
         ::   If don't do this, can get bad state starting
         ::   up a new indexer.
-        =:  batches-by-shard        ~
+        =:  batches-by-town        ~
             capitol                 ~
             sequencer-update-queue  ~
-            shard-update-queue      ~
+            town-update-queue      ~
             old-sub-paths           ~
             old-sub-updates         ~
             txn-index               ~
@@ -529,48 +529,48 @@
             holder-index            ~
             source-index            ~
             to-index                ~
-            newest-batch-by-shard   ~
+            newest-batch-by-town   ~
         ==
         `this(state (set-state-from-vase q.cage.sign))
       ==
     ::
         [%indexer-catchup-update @ @ ~]
-      =/  shard-id=id:smart  (slav %ux i.t.wire)
+      =/  town-id=id:smart  (slav %ux i.t.wire)
       =/  root=id:smart      (slav %ux i.t.t.wire)
       ?+    -.sign  (on-agent:def wire sign)
           %fact
         :-  ~
         =+  !<([=batches:ui =batch-order:ui] q.cage.sign)
         =/  old=(unit (pair batches:ui batch-order:ui))
-          (~(get by batches-by-shard) shard-id)
+          (~(get by batches-by-town) town-id)
         ?~  old
           %=  this
-              batches-by-shard
-            %+  ~(put by batches-by-shard)  shard-id
+              batches-by-town
+            %+  ~(put by batches-by-town)  town-id
             [batches batch-order]
           ==
         =/  root-index=@ud
           ?~(i=(find ~[root] q.u.old) 0 +(u.i))
-        =.  batches-by-shard
-          %+  ~(put by batches-by-shard)  shard-id
+        =.  batches-by-town
+          %+  ~(put by batches-by-town)  town-id
           :-  (~(uni by p.u.old) batches)
           (weld batch-order (slag root-index q.u.old))
         %=  this
             sequencer-update-queue  ~
-            shard-update-queue       ~
+            town-update-queue       ~
             +.state
           %-  inflate-state
-          ~(tap by batches-by-shard)
+          ~(tap by batches-by-town)
         ==
       ==
     ==
     ::
     ++  has-root-already
-      |=  [shard-id=id:smart root=id:smart]
+      |=  [town-id=id:smart root=id:smart]
       ^-  ?
       =/  [=batches:ui *]
-        %+  %~  gut  by  batches-by-shard
-        shard-id  [*batches:ui *batches-by-shard:ui]
+        %+  %~  gut  by  batches-by-town
+        town-id  [*batches:ui *batches-by-town:ui]
       (~(has by batches) root)
     ::
     ++  consume-sequencer-update
@@ -578,22 +578,22 @@
       ^-  (quip card _state)
       ?-    -.update
           %update
-        =*  shard-id  shard-id.hall.update
+        =*  town-id  town-id.hall.update
         =*  root     root.update
-        ?:  (has-root-already shard-id root)  `state
+        ?:  (has-root-already town-id root)  `state
         ?.  =(root (sham chain.update))       `state
         =/  timestamp=(unit @da)
           %.  root
           %~  get  by
-          %+  ~(gut by shard-update-queue)  shard-id
+          %+  ~(gut by town-update-queue)  town-id
           *(map @ux @da)
         ?~  timestamp
           :-  ~
           %=  state
               sequencer-update-queue
-            %+  ~(put by sequencer-update-queue)  shard-id
+            %+  ~(put by sequencer-update-queue)  town-id
             %+  %~  put  by
-                %+  ~(gut by sequencer-update-queue)  shard-id
+                %+  ~(gut by sequencer-update-queue)  town-id
                 *(map @ux batch:ui)
               root
             [transactions.update [chain.update hall.update]]
@@ -608,10 +608,10 @@
           ==
         :-  cards
         %=  state
-            shard-update-queue
-          %+  ~(put by shard-update-queue)  shard-id
+            town-update-queue
+          %+  ~(put by town-update-queue)  town-id
           %.  root
-          ~(del by (~(got by shard-update-queue) shard-id))
+          ~(del by (~(got by town-update-queue) town-id))
         ==
       ==
     ::
@@ -632,9 +632,9 @@
             ~
         ?:  (only-missing-newest capitol.update)  ~
         %+  murn  ~(val by capitol.update)
-        |=  [shard-id=id:smart @ [@ @] [@ *] @ roots=(list @ux)]
+        |=  [town-id=id:smart @ [@ @] [@ *] @ roots=(list @ux)]
         =/  [* =batch-order:ui]
-          %+  ~(gut by batches-by-shard)  shard-id
+          %+  ~(gut by batches-by-town)  town-id
           [~ batch-order=~]
         =/  needed-list=(list id:smart)
           (find-needed-batches roots batch-order)
@@ -642,27 +642,27 @@
         =*  root  i.needed-list
         :-  ~
         %^    watch-target:ic
-            (indexer-catchup-wire shard-id root)
+            (indexer-catchup-wire town-id root)
           catchup-indexer
-        (indexer-catchup-path shard-id root)
+        (indexer-catchup-path town-id root)
       ::
           %new-peer-root
-        =*  shard-id  shard.update
+        =*  town-id  town.update
         =*  root     root.update
-        ?:  (has-root-already shard-id root)  `state
+        ?:  (has-root-already town-id root)  `state
         =/  sequencer-update
-          ^-  (unit [txns=(list [@ux transaction:smart]) =shard:seq])
+          ^-  (unit [txns=(list [@ux transaction:smart]) =town:seq])
           %.  root
           %~  get  by
-          %+  ~(gut by sequencer-update-queue)  shard-id
+          %+  ~(gut by sequencer-update-queue)  town-id
           *(map @ux batch:ui)
         ?~  sequencer-update
           :-  ~
           %=  state
-              shard-update-queue
-            %+  ~(put by shard-update-queue)  shard-id
+              town-update-queue
+            %+  ~(put by town-update-queue)  town-id
             %+  %~  put  by
-                %+  ~(gut by shard-update-queue)  shard-id
+                %+  ~(gut by town-update-queue)  town-id
                 *(map batch-id=@ux timestamp=@da)
             root  timestamp.update
           ==
@@ -670,14 +670,14 @@
           %:  consume-batch:ic
               root
               txns.u.sequencer-update
-              shard.u.sequencer-update
+              town.u.sequencer-update
               timestamp.update
               %.y
           ==
         :-  cards
         %=  state
             sequencer-update-queue
-          %+  ~(jab by sequencer-update-queue)  shard-id
+          %+  ~(jab by sequencer-update-queue)  town-id
           |=  queue=(map @ux batch:ui)
           (~(del by queue) root)
         ==
@@ -704,21 +704,21 @@
       ++  only-missing-newest
         |=  new-capitol=capitol:seq
         ^-  ?
-        =/  shard-ids=(list id:smart)
+        =/  town-ids=(list id:smart)
           ~(tap in ~(key by new-capitol))
         |-
-        ?~  shard-ids  %.y
-        =*  shard-id  i.shard-ids
+        ?~  town-ids  %.y
+        =*  town-id  i.town-ids
         =/  old-roots=batch-order:ui
-          roots:(~(gut by capitol) shard-id *hall:seq)
+          roots:(~(gut by capitol) town-id *hall:seq)
         =/  new-roots=batch-order:ui
-          roots:(~(gut by new-capitol) shard-id *hall:seq)
-        ?~  old-roots  $(shard-ids t.shard-ids)
+          roots:(~(gut by new-capitol) town-id *hall:seq)
+        ?~  old-roots  $(town-ids t.town-ids)
         ?~  new-roots  %.n
         =/  l-old=@ud  (lent old-roots)
         =/  l-new=@ud  (lent new-roots)
         ?.  |(=(l-old l-new) =(l-old (dec l-new)))  %.n
-        $(shard-ids t.shard-ids)
+        $(town-ids t.town-ids)
       --
     --
   ::
@@ -747,9 +747,9 @@
   /indexer-bootstrap-update
 ::
 ++  indexer-catchup-wire
-  |=  [shard-id=id:smart root=id:smart]
+  |=  [town-id=id:smart root=id:smart]
   ^-  wire
-  /indexer-catchup-update/(scot %ux shard-id)/(scot %ux root)
+  /indexer-catchup-update/(scot %ux town-id)/(scot %ux root)
 ::
 ++  rollup-capitol-path
   ^-  path
@@ -768,9 +768,9 @@
   /indexer-bootstrap
 ::
 ++  indexer-catchup-path
-  |=  [shard-id=id:smart root=id:smart]
+  |=  [town-id=id:smart root=id:smart]
   ^-  path
-  /indexer-catchup/(scot %ux shard-id)/(scot %ux root)
+  /indexer-catchup/(scot %ux town-id)/(scot %ux root)
 ::
 ++  watch-target
   |=  [w=wire d=dock p=path]
@@ -810,16 +810,16 @@
   [s.wex t.wex]
 ::
 ++  get-batch
-  |=  [shard-id=id:smart batch-root=id:smart]
+  |=  [town-id=id:smart batch-root=id:smart]
   ^-  (unit [batch-id=id:smart timestamp=@da =batch:ui])
-  ?~  bs=(~(get by batches-by-shard) shard-id)  ~
+  ?~  bs=(~(get by batches-by-town) town-id)  ~
   ?~  b=(~(get by batches.u.bs) batch-root)     ~
   `[batch-root u.b]
 ::
 ++  get-newest-batch
-  |=  [shard-id=id:smart expected-root=id:smart]
+  |=  [town-id=id:smart expected-root=id:smart]
   ^-  (unit [batch-id=id:smart timestamp=@da =batch:ui])
-  ?~  b=(~(get by newest-batch-by-shard) shard-id)  ~
+  ?~  b=(~(get by newest-batch-by-town) town-id)  ~
   ?.  =(expected-root batch-id.u.b)                 ~
   `u.b
 ::
@@ -847,18 +847,18 @@
   =/  holder=update:ui  (serve-update %holder qp options)
   =/  source=update:ui  (serve-update %source qp options)
   =/  to=update:ui      (serve-update %to qp options)
-  =/  shard=update:ui   (serve-update %shard qp options)
+  =/  town=update:ui   (serve-update %town qp options)
   :: =/  item-txns=update:ui
   ::   (serve-update %item-txns qp only-newest)
-  %^  combine-updates  ~[batch shard]  ~[txn from to]
+  %^  combine-updates  ~[batch town]  ~[txn from to]
   ~[item holder source]
 ::
 ++  combine-batch-updates-to-map
   |=  updates=(list update:ui)
-  ^-  (map id:smart [@da shard-location:ui batch:ui])
+  ^-  (map id:smart [@da town-location:ui batch:ui])
   ?~  updates  ~
   %-  %~  gas  by
-      *(map id:smart [@da shard-location:ui batch:ui])
+      *(map id:smart [@da town-location:ui batch:ui])
   %-  zing
   %+  turn  updates
   |=  =update:ui
@@ -911,7 +911,7 @@
           ?=(~ item-updates)
       ==
     ~
-  =/  combined-batch=(map id:smart [@da shard-location:ui batch:ui])
+  =/  combined-batch=(map id:smart [@da town-location:ui batch:ui])
     (combine-batch-updates-to-map batch-updates)
   =/  combined-txn=(map id:smart [@da txn-location:ui transaction:smart])
     (combine-txn-updates-to-map txn-updates)
@@ -931,7 +931,7 @@
   ?-    -.vs
       %0
     :_  %-  inflate-state
-        ~(tap by batches-by-shard.vs)
+        ~(tap by batches-by-town.vs)
     %=  vs
       old-sub-paths    ~
       old-sub-updates  ~
@@ -940,23 +940,23 @@
   ==
 ::
 ++  inflate-state
-  |=  batches-by-shard-list=(list [@ux =batches:ui =batch-order:ui])
+  |=  batches-by-town-list=(list [@ux =batches:ui =batch-order:ui])
   ^-  indices-0:ui
   =|  temporary-state=_state
   |^
-  ?~  batches-by-shard-list  +.temporary-state
+  ?~  batches-by-town-list  +.temporary-state
   =/  batches-list=(list [root=@ux timestamp=@da =batch:ui])
-    %+  murn  (flop batch-order.i.batches-by-shard-list)
+    %+  murn  (flop batch-order.i.batches-by-town-list)
     |=  =id:smart
-    ?~  batch=(~(get by batches.i.batches-by-shard-list) id)
+    ?~  batch=(~(get by batches.i.batches-by-town-list) id)
       ~
     `[id u.batch]
   %=  $
-      batches-by-shard-list  t.batches-by-shard-list
-      temporary-state       (inflate-shard batches-list)
+      batches-by-town-list  t.batches-by-town-list
+      temporary-state       (inflate-town batches-list)
   ==
   ::
-  ++  inflate-shard
+  ++  inflate-town
     |=  batches-list=(list [root=@ux timestamp=@da =batch:ui])
     ^-  _state
     |-
@@ -993,50 +993,50 @@
       ?(%txn %from %item %holder %source %to)
     get-from-index
   ::
-      %shard
-    get-shard
+      %town
+    get-town
   ==
   ::
-  ++  get-shard
+  ++  get-town
     ?.  ?=(@ query-payload)  ~
-    =*  shard-id  query-payload
-    ?~  bs=(~(get by batches-by-shard) shard-id)  ~
+    =*  town-id  query-payload
+    ?~  bs=(~(get by batches-by-town) town-id)  ~
     ?:  only-newest
       ?~  batch-order.u.bs  ~
       =*  batch-id  i.batch-order.u.bs
       ?~  b=(~(get by batches.u.bs) batch-id)  ~
       :-  %newest-batch
-      [batch-id timestamp.u.b shard-id batch.u.b]
+      [batch-id timestamp.u.b town-id batch.u.b]
     :-  %batch
     %-  %~  gas  by
-        *(map id:smart [@da shard-location:ui batch:ui])
+        *(map id:smart [@da town-location:ui batch:ui])
     %+  turn  ~(tap by batches.u.bs)
     |=  [batch-id=id:smart timestamp=@da =batch:ui]
-    [batch-id [timestamp shard-id batch]]
+    [batch-id [timestamp town-id batch]]
   ::
   ++  get-batch-update
     ?:  ?=([@ @] query-payload)
-      =*  shard-id   -.query-payload
+      =*  town-id   -.query-payload
       =*  batch-id  +.query-payload
-      ?~  b=(get-appropriate-batch shard-id batch-id)  ~
+      ?~  b=(get-appropriate-batch town-id batch-id)  ~
       =*  timestamp  timestamp.u.b
       =*  batch      batch.u.b
       :-  %batch
       %+  %~  put  by
-          *(map id:smart [@da shard-location:ui batch:ui])
-      batch-id  [timestamp shard-id batch]
+          *(map id:smart [@da town-location:ui batch:ui])
+      batch-id  [timestamp town-id batch]
     ?.  ?=(@ query-payload)  ~
     =*  batch-id  query-payload
-    =/  out=[%batch (map id:smart [@da shard-location:ui batch:ui])]
-      %+  roll  ~(tap in ~(key by batches-by-shard))
-      |=  $:  shard-id=id:smart
-              out=[%batch (map id:smart [@da shard-location:ui batch:ui])]
+    =/  out=[%batch (map id:smart [@da town-location:ui batch:ui])]
+      %+  roll  ~(tap in ~(key by batches-by-town))
+      |=  $:  town-id=id:smart
+              out=[%batch (map id:smart [@da town-location:ui batch:ui])]
           ==
-      ?~  b=(get-appropriate-batch shard-id batch-id)  out
+      ?~  b=(get-appropriate-batch town-id batch-id)  out
       =*  timestamp  timestamp.u.b
       =*  batch      batch.u.b
       :-  %batch
-      (~(put by +.out) batch-id [timestamp shard-id batch])
+      (~(put by +.out) batch-id [timestamp town-id batch])
     ?~(+.out ~ out)
   ::
   ++  get-from-index
@@ -1064,9 +1064,9 @@
         ?~  locations  ~
         =*  location  i.locations
         ?.  ?=(batch-location:ui location)  ~
-        =*  shard-id     shard-id.location
+        =*  town-id     town-id.location
         =*  batch-root  batch-root.location
-        ?~  b=(get-appropriate-batch shard-id batch-root)  ~
+        ?~  b=(get-appropriate-batch town-id batch-root)  ~
         ?.  |(!only-newest =(batch-root batch-id.u.b))
           ::  TODO: remove this check if we never see this log
           ~&  >>>  "%indexer: unexpected batch root (item)"
@@ -1083,9 +1083,9 @@
       =*  location  i.locations
       ?.  ?=(batch-location:ui location)
         $(locations t.locations)
-      =*  shard-id     shard-id.location
+      =*  town-id     town-id.location
       =*  batch-root  batch-root.location
-      ?~  b=(get-appropriate-batch shard-id batch-root)
+      ?~  b=(get-appropriate-batch town-id batch-root)
         $(locations t.locations)
       ?.  |(!only-newest =(batch-root batch-id.u.b))
         ::  TODO: remove this check if we never see this log
@@ -1108,10 +1108,10 @@
         ?~  locations  ~
         =*  location  i.locations
         ?.  ?=(txn-location:ui location)  ~
-        =*  shard-id     shard-id.location
+        =*  town-id     town-id.location
         =*  batch-root  batch-root.location
         =*  txn-num     txn-num.location
-        ?~  b=(get-appropriate-batch shard-id batch-root)  ~
+        ?~  b=(get-appropriate-batch town-id batch-root)  ~
         ?.  |(!only-newest =(batch-root batch-id.u.b))
           ::  happens for second-order only-newest queries that
           ::   resolve to txns because get-locations does not
@@ -1128,10 +1128,10 @@
       =*  location  i.locations
       ?.  ?=(txn-location:ui location)
         $(locations t.locations)
-      =*  shard-id     shard-id.location
+      =*  town-id     town-id.location
       =*  batch-root  batch-root.location
       =*  txn-num     txn-num.location
-      ?~  b=(get-appropriate-batch shard-id batch-root)
+      ?~  b=(get-appropriate-batch town-id batch-root)
         $(locations t.locations)
       ?.  |(!only-newest =(batch-root batch-id.u.b))
         ::  happens for second-order only-newest queries that
@@ -1297,57 +1297,57 @@
       |=  [index=(map @ux (jar @ux location:ui)) only-newest=?]
       ^-  (list location:ui)
       ?:  ?=([@ @] query-payload)
-        =*  shard-id    -.query-payload
+        =*  town-id    -.query-payload
         =*  item-hash   +.query-payload
-        ?~  shard-index=(~(get by index) shard-id)     ~
-        ?~  items=(~(get ja u.shard-index) item-hash)  ~
+        ?~  town-index=(~(get by index) town-id)     ~
+        ?~  items=(~(get ja u.town-index) item-hash)  ~
         ?:(only-newest ~[i.items] items)
       ?.  ?=(@ query-payload)  ~
       =*  item-hash  query-payload
       %+  roll  ~(val by index)
-      |=  [shard-index=(jar @ux location:ui) out=(list location:ui)]
-      ?~  items=(~(get ja shard-index) item-hash)  out
+      |=  [town-index=(jar @ux location:ui) out=(list location:ui)]
+      ?~  items=(~(get ja town-index) item-hash)  out
       ?:  only-newest  [i.items out]
-      (weld out (~(get ja shard-index) item-hash))
+      (weld out (~(get ja town-index) item-hash))
     --
   --
 ::
 ++  consume-batch
   |=  $:  root=@ux
           txns=(list [@ux transaction:smart])
-          =shard:seq
+          =town:seq
           timestamp=@da
           should-update-subs=?
       ==
-  =*  shard-id  shard-id.hall.shard
+  =*  town-id  town-id.hall.town
   |^  ^-  (quip card _state)
   =+  ^=  [txn from item holder source to]
-      (parse-batch root shard-id txns chain.shard)
-  =:  txn-index        (gas-ja-txn txn-index txn shard-id)
-      from-index       (gas-ja-second-order from-index from shard-id)
-      item-index       (gas-ja-batch item-index item shard-id)
-      :: item-txns-index  (gas-ja-second-order item-txns-index item-txns shard-id)
-      holder-index     (gas-ja-second-order holder-index holder shard-id)
-      source-index     (gas-ja-second-order source-index source shard-id)
-      to-index         (gas-ja-second-order to-index to shard-id)
-      newest-batch-by-shard
-    ::  only update newest-batch-by-shard with newer batches
+      (parse-batch root town-id txns chain.town)
+  =:  txn-index        (gas-ja-txn txn-index txn town-id)
+      from-index       (gas-ja-second-order from-index from town-id)
+      item-index       (gas-ja-batch item-index item town-id)
+      :: item-txns-index  (gas-ja-second-order item-txns-index item-txns town-id)
+      holder-index     (gas-ja-second-order holder-index holder town-id)
+      source-index     (gas-ja-second-order source-index source town-id)
+      to-index         (gas-ja-second-order to-index to town-id)
+      newest-batch-by-town
+    ::  only update newest-batch-by-town with newer batches
     ?:  %+  gth
-          ?~  current=(~(get by newest-batch-by-shard) shard-id)
+          ?~  current=(~(get by newest-batch-by-town) town-id)
             *@da
           timestamp.u.current
         timestamp
-      newest-batch-by-shard
-    %+  ~(put by newest-batch-by-shard)  shard-id
-    [root timestamp txns shard]
+      newest-batch-by-town
+    %+  ~(put by newest-batch-by-town)  town-id
+    [root timestamp txns town]
   ::
-      batches-by-shard
-    %+  ~(put by batches-by-shard)  shard-id
-    ?~  b=(~(get by batches-by-shard) shard-id)
+      batches-by-town
+    %+  ~(put by batches-by-town)  town-id
+    ?~  b=(~(get by batches-by-town) town-id)
       :_  ~[root]
-      (malt ~[[root [timestamp txns shard]]])
+      (malt ~[[root [timestamp txns town]]])
     :_  [root batch-order.u.b]
-    (~(put by batches.u.b) root [timestamp txns shard])
+    (~(put by batches.u.b) root [timestamp txns town])
   ==
   ?.  should-update-subs  [~ state]
   =/  all-sub-cards  make-all-sub-cards
@@ -1365,49 +1365,49 @@
   ++  gas-ja-txn
     |=  $:  index=txn-index:ui
             new=(list [hash=@ux location=txn-location:ui])
-            shard-id=id:smart
+            town-id=id:smart
         ==
-    %+  ~(put by index)  shard-id
-    =/  shard-index=(jar @ux txn-location:ui)
-      ?~(ti=(~(get by index) shard-id) ~ u.ti)
+    %+  ~(put by index)  town-id
+    =/  town-index=(jar @ux txn-location:ui)
+      ?~(ti=(~(get by index) town-id) ~ u.ti)
     |-
-    ?~  new  shard-index
+    ?~  new  town-index
     %=  $
         new  t.new
-        shard-index
-      (~(add ja shard-index) hash.i.new location.i.new)
+        town-index
+      (~(add ja town-index) hash.i.new location.i.new)
     ==
   ::
   ++  gas-ja-batch
     |=  $:  index=batch-index:ui
             new=(list [hash=@ux location=batch-location:ui])
-            shard-id=id:smart
+            town-id=id:smart
         ==
-    %+  ~(put by index)  shard-id
-    =/  shard-index=(jar @ux batch-location:ui)
-      ?~(ti=(~(get by index) shard-id) ~ u.ti)
+    %+  ~(put by index)  town-id
+    =/  town-index=(jar @ux batch-location:ui)
+      ?~(ti=(~(get by index) town-id) ~ u.ti)
     |-
-    ?~  new  shard-index
+    ?~  new  town-index
     %=  $
         new  t.new
-        shard-index
-      (~(add ja shard-index) hash.i.new location.i.new)
+        town-index
+      (~(add ja town-index) hash.i.new location.i.new)
     ==
   ::
   ++  gas-ja-second-order
     |=  $:  index=second-order-index:ui
             new=(list [hash=@ux location=second-order-location:ui])
-            shard-id=id:smart
+            town-id=id:smart
         ==
-    %+  ~(put by index)  shard-id
-    =/  shard-index=(jar @ux second-order-location:ui)
-      (~(gut by index) shard-id ~)
+    %+  ~(put by index)  town-id
+    =/  town-index=(jar @ux second-order-location:ui)
+      (~(gut by index) town-id ~)
     |-
-    ?~  new  shard-index
+    ?~  new  town-index
     %=  $
         new  t.new
-        shard-index
-      (~(add ja shard-index) hash.i.new location.i.new)
+        town-index
+      (~(add ja town-index) hash.i.new location.i.new)
     ==
   ::
   ++  make-sub-paths
@@ -1417,7 +1417,7 @@
     |=  [ship sub-path=path]
     ^-  (unit [@tas path])
     ?~  sub-path  ~
-    ?.  ?=  ?(%batch-order %item %hash %holder %id %json %source %shard)
+    ?.  ?=  ?(%batch-order %item %hash %holder %id %json %source %town)
         i.sub-path
       ~
     `[`@tas`i.sub-path t.sub-path]
@@ -1439,7 +1439,7 @@
             %id
             %json
             %source
-            %shard
+            %town
         ==
       |=  $:  query-type=?(%batch-order %id %json query-type:ui)
               out=[cards=(list (list card)) paths=(list (list [path @ux])) updates=(list (list [@ux update:ui]))]
@@ -1482,7 +1482,7 @@
             %holder
           (serve-update query-type payload %.y %.n)
         ::
-            ?(%item %source %shard)
+            ?(%item %source %town)
           (serve-update query-type payload %.y %.y)
         ==
       ?~  update  out
@@ -1676,7 +1676,7 @@
   ::
   ++  parse-batch
     |=  $:  root=@ux
-            shard-id=@ux
+            town-id=@ux
             txns=(list [@ux transaction:smart])
             =chain:seq
         ==
@@ -1687,12 +1687,12 @@
             (list [@ux second-order-location:ui])
             (list [@ux second-order-location:ui])
         ==
-    =+  [item holder source]=(parse-state root shard-id p.chain)
-    =+  [txn from to]=(parse-transactions root shard-id txns)
+    =+  [item holder source]=(parse-state root town-id p.chain)
+    =+  [txn from to]=(parse-transactions root town-id txns)
     [txn from item holder source to]
   ::
   ++  parse-state
-    |=  [root=@ux shard-id=@ux =state:seq]
+    |=  [root=@ux town-id=@ux =state:seq]
     ^-  $:  (list [@ux batch-location:ui])
             (list [@ux second-order-location:ui])
             (list [@ux second-order-location:ui])
@@ -1711,28 +1711,28 @@
         items         t.items
     ::
         parsed-holder
-      ?:  %+  exists-in-index  shard-id
+      ?:  %+  exists-in-index  town-id
           [holder-id item-id holder-index]
         parsed-holder
       [[holder-id item-id] parsed-holder]
     ::
         parsed-source
-      ?:  %+  exists-in-index  shard-id
+      ?:  %+  exists-in-index  town-id
           [source-id item-id source-index]
         parsed-source
       [[source-id item-id] parsed-source]
     ::
         parsed-item
-      ?:  %+  exists-in-index  shard-id
-          [item-id [shard-id root] item-index]
+      ?:  %+  exists-in-index  town-id
+          [item-id [town-id root] item-index]
         parsed-item
       :_  parsed-item
       :-  item-id
-      [shard-id root]
+      [town-id root]
     ==
   ::
   ++  parse-transactions
-    |=  [root=@ux shard-id=@ux txs=(list [@ux transaction:smart])]
+    |=  [root=@ux town-id=@ux txs=(list [@ux transaction:smart])]
     ^-  $:  (list [@ux txn-location:ui])
             (list [@ux second-order-location:ui])
             (list [@ux second-order-location:ui])
@@ -1747,40 +1747,40 @@
     =*  txn          +.i.txs
     =*  contract     contract.txn
     =*  from         address.caller.txn
-    =/  =txn-location:ui  [shard-id root txn-num]
+    =/  =txn-location:ui  [town-id root txn-num]
     %=  $
         txn-num      +(txn-num)
         txs          t.txs
         parsed-txn
-      ?:  %+  exists-in-index  shard-id
+      ?:  %+  exists-in-index  town-id
           [txn-hash txn-location txn-index]
         parsed-txn
       [[txn-hash txn-location] parsed-txn]
     ::
         parsed-from
-      ?:  %+  exists-in-index  shard-id
+      ?:  %+  exists-in-index  town-id
           [from txn-hash from-index]
         parsed-from
       [[from txn-hash] parsed-from]
     ::
         parsed-to
-      ?:  %+  exists-in-index  shard-id
+      ?:  %+  exists-in-index  town-id
           [contract txn-hash to-index]
         parsed-to
       [[contract txn-hash] parsed-to]
     ==
   ::
   ++  exists-in-index
-    |=  $:  shard-id=@ux
+    |=  $:  town-id=@ux
             key=@ux
             val=location:ui
             index=location-index:ui
         ==
     ^-  ?
-    ?~  shard-index=(~(get by index) shard-id)  %.n
+    ?~  town-index=(~(get by index) town-id)  %.n
     %.  val
     %~  has  in
     %-  %~  gas  in  *(set location:ui)
-    (~(get ja u.shard-index) key)
+    (~(get ja u.town-index) key)
   --
 --

--- a/app/rollup.hoon
+++ b/app/rollup.hoon
@@ -1,7 +1,7 @@
 ::  rollup [UQ| DAO]
 ::
 ::  Agent that simulates a rollup contract on another chain.
-::  Receives state transitions (moves) for shards, verifies them,
+::  Receives state transitions (moves) for towns, verifies them,
 ::  and allows sequencer ships to continue processing batches.
 ::
 /+  default-agent, dbug, verb, ethereum,
@@ -39,7 +39,7 @@
     ~|("%rollup: error: got watch while not active" !!)
   ::  open: anyone can watch rollup
   ::  ?>  (allowed-participant [src our now]:bowl)
-  ::  give new subscribers recent root from every shard
+  ::  give new subscribers recent root from every town
   ::
   ?+    path  !!
       [%capitol-updates ~]
@@ -55,7 +55,7 @@
     ::  send bunted @da here as placeholder/null time.
     ::  may in future have canonical batch times
     =-  [%give %fact ~ -]
-    [%sequencer-rollup-update !>(`shard-update`[%new-peer-root id (rear roots.hall) *@da])]
+    [%sequencer-rollup-update !>(`town-update`[%new-peer-root id (rear roots.hall) *@da])]
   ==
 ::
 ++  on-poke
@@ -77,15 +77,15 @@
         %activate
       `state(status %available)
     ::
-        %launch-shard
+        %launch-town
       ::  create new hall
-      ?<  (~(has by capitol) shard-id.hall.act)
-      ::  TODO remove starting-state from init and populate new shards via
-      ::  assets from other shards
-      =+  (~(put by capitol) shard-id.hall.act hall.act)
+      ?<  (~(has by capitol) town-id.hall.act)
+      ::  TODO remove starting-state from init and populate new towns via
+      ::  assets from other towns
+      =+  (~(put by capitol) town-id.hall.act hall.act)
       :_  state(capitol -)
       :~  =-  [%give %fact ~[/peer-root-updates] %sequencer-rollup-update -]
-          !>(`shard-update`[%new-peer-root shard-id.hall.act (rear roots.hall.act) now.bowl])
+          !>(`town-update`[%new-peer-root town-id.hall.act (rear roots.hall.act) now.bowl])
       ::
           =-  [%give %fact ~[/capitol-updates] %sequencer-rollup-update -]
           !>(`capitol-update`[%new-capitol -])
@@ -93,16 +93,16 @@
     ::
         %bridge-assets
       ::  for simulation purposes
-      ?~  hall=(~(get by capitol.state) shard-id.act)  !!
+      ?~  hall=(~(get by capitol.state) town-id.act)  !!
       :_  state
-      =+  [%shard-action !>([%receive-assets assets.act])]
+      =+  [%town-action !>([%receive-assets assets.act])]
       [%pass /bridge %agent [q.sequencer.u.hall %sequencer] %poke -]~
     ::
         %receive-batch
-      ?~  hall=(~(get by capitol.state) shard-id.act)
-        ~|("%rollup: rejecting batch; shard not found" !!)
+      ?~  hall=(~(get by capitol.state) town-id.act)
+        ~|("%rollup: rejecting batch; town not found" !!)
       ?.  =([from.act src.bowl] sequencer.u.hall)
-        ~|("%rollup: rejecting batch; sequencer doesn't match shard" !!)
+        ~|("%rollup: rejecting batch; sequencer doesn't match town" !!)
       =/  recovered
         %-  address-from-pub:key:ethereum
         %-  serialize-point:secp256k1:secp:crypto
@@ -112,7 +112,7 @@
         ~|("%rollup: rejecting batch; sequencer signature not valid" !!)
       ?.  =(diff-hash.act (sham state-diffs.act))
         ~|("%rollup: rejecting batch; diff hash not valid" !!)
-      ::  check that other shard state roots are up-to-date
+      ::  check that other town state roots are up-to-date
       ::  recent-enough is a variable here that can be adjusted
       =/  recent-enough  2
       ?.  %+  levy
@@ -137,10 +137,10 @@
             latest-diff-hash  diff-hash.act
             roots  (snoc roots.u.hall new-root.act)
           ==
-      =+  (~(put by capitol) shard-id.act -)
+      =+  (~(put by capitol) town-id.act -)
       :_  state(capitol -)
       :~  =-  [%give %fact ~[/peer-root-updates] %sequencer-rollup-update -]
-          !>(`shard-update`[%new-peer-root shard-id.act new-root.act now.bowl])
+          !>(`town-update`[%new-peer-root town-id.act new-root.act now.bowl])
       ::
           =-  [%give %fact ~[/capitol-updates] %sequencer-rollup-update -]
           !>(`capitol-update`[%new-capitol -])

--- a/app/uqbar.hoon
+++ b/app/uqbar.hoon
@@ -23,9 +23,9 @@
       ping-time-fast-delay=@dr
       ping-timeout=@dr
       pings-timedout=(unit @da)
-      indexer-sources=(jug id:smart dock)  ::  set of indexers for each shard
+      indexer-sources=(jug id:smart dock)  ::  set of indexers for each town
       =indexer-sources-ping-results:u
-      sequencers=(map id:smart sequencer:s)  ::  single sequencer for each shard
+      sequencers=(map id:smart sequencer:s)  ::  single sequencer for each town
       wallet-source=@tas
   ==
 --
@@ -81,10 +81,10 @@
     ::
         %indexer
       ::  must be of the form, e.g.,
-      ::   /indexer/[requesting-app-name]/grain/[shard-id]/[grain-id]
+      ::   /indexer/[requesting-app-name]/grain/[town-id]/[grain-id]
       ?.  ?=([%indexer @ @ ^] path)  ~
-      =/  shard=id:smart  (slav %ux i.t.t.t.path)
-      (watch-indexer shard /[i.path]/[i.t.path] t.t.path)
+      =/  town=id:smart  (slav %ux i.t.t.t.path)
+      (watch-indexer town /[i.path]/[i.t.path] t.t.path)
     ==
     ::
     ++  watch-wallet
@@ -95,12 +95,12 @@
       wallet-source  sub-path
     ::
     ++  watch-indexer  ::  TODO: use fallback better?
-      |=  [shard=id:smart wire-prefix=wire sub-path=^path]
+      |=  [town=id:smart wire-prefix=wire sub-path=^path]
       ^-  (list card)
-      ?~  source=(get-best-source:uc shard ~ %nu)
+      ?~  source=(get-best-source:uc town ~ %nu)
         ~&  >>>  "%uqbar: subscription failed:"
-        ~&  >>>  " do not have indexer source for shard {<shard>}."
-        ~&  >>>  " Add indexer source for shard and try again."
+        ~&  >>>  " do not have indexer source for town {<town>}."
+        ~&  >>>  " Add indexer source for town and try again."
         ~
       =/  disambiguator=@ta  (scot %ux (cut 5 [0 1] eny.bowl))
       :_  ~
@@ -161,7 +161,7 @@
             [%uqbar-action !>(`action:u`[%ping ~])]
         %=  state
             indexer-sources
-          (~(put ju indexer-sources) shard.act source.act)
+          (~(put ju indexer-sources) town.act source.act)
         ==
       ::
           %remove-source
@@ -171,12 +171,12 @@
         %=  state
             indexer-sources-ping-results
           %^    remove-from-ping-results
-              shard.act
+              town.act
             source.act
           indexer-sources-ping-results
         ::
             indexer-sources
-          (~(del ju indexer-sources) shard.act source.act)
+          (~(del ju indexer-sources) town.act source.act)
         ==
       ::
           %set-sources
@@ -184,43 +184,43 @@
           /capitol-updates/[(scot %ux (cut 5 [0 1] eny.bowl))]
         :-  :-  %-  ~(poke-self pass:io /ping-action-poke)
                 [%uqbar-action !>(`action:u`[%ping ~])]
-            %+  murn  shards.act
-            |=  [shard=id:smart indexers=(set dock)]
+            %+  murn  towns.act
+            |=  [town=id:smart indexers=(set dock)]
             ?~  indexers  ~
             `(~(watch pass:io p) -.indexers p)  ::  TODO: do better here
         %=  state
             indexer-sources-ping-results
-          (set-sources-remove-from-ping-results shards.act)
+          (set-sources-remove-from-ping-results towns.act)
         ::
             indexer-sources
-          (~(gas by *(map id:smart (set dock))) shards.act)
+          (~(gas by *(map id:smart (set dock))) towns.act)
         ==
       ==
       ::
       ++  remove-from-ping-results
-        |=  $:  shard=id:smart
+        |=  $:  town=id:smart
                 source=dock
                 =indexer-sources-ping-results:u
             ==
         ^-  indexer-sources-ping-results:u
         =/  old
           %+  ~(gut by indexer-sources-ping-results)
-          shard  [~ ~ ~ ~]
+          town  [~ ~ ~ ~]
         ?:  ?=([~ ~ ~ ~] old)  indexer-sources-ping-results
         %+  ~(put by indexer-sources-ping-results)
-          shard
+          town
         :^    (~(del in previous-up.old) source)
             (~(del in previous-down.old) source)
           (~(del in newest-up.old) source)
         (~(del in newest-down.old) source)
       ::
       ++  set-sources-remove-from-ping-results
-        |=  shards=(list [shard=id:smart (set dock)])
+        |=  towns=(list [town=id:smart (set dock)])
         ^-  indexer-sources-ping-results:u
-        ?~  shards  indexer-sources-ping-results
-        =/  docks=(list dock)  ~(tap in +.i.shards)
+        ?~  towns  indexer-sources-ping-results
+        =/  docks=(list dock)  ~(tap in +.i.towns)
         %=  $
-            shards  t.shards
+            towns  t.towns
             indexer-sources-ping-results
           |-
           ?~  docks  indexer-sources-ping-results
@@ -228,7 +228,7 @@
               docks  t.docks
               indexer-sources-ping-results
             %^    remove-from-ping-results
-                shard.i.shards
+                town.i.towns
               i.docks
             indexer-sources-ping-results
           ==
@@ -241,16 +241,16 @@
       ?-    -.write
           %submit
         ::  forward a transaction to sequencer we're tracking
-        ::  for the specified shard
+        ::  for the specified town
         ?>  =(src.bowl our.bowl)
-        ?~  seq=(~(get by sequencers.state) `@ux`shard.txn.write)
-          ~|("%uqbar: no known sequencer for that shard" !!)
+        ?~  seq=(~(get by sequencers.state) `@ux`town.txn.write)
+          ~|("%uqbar: no known sequencer for that town" !!)
         =/  txn-hash  (scot %ux `@ux`(sham +.txn.write))
         :_  state
         :+  %+  ~(poke pass:io /submit-transaction/txn-hash)
               [q.u.seq %sequencer]
-            :-  %sequencer-shard-action
-            !>(`shard-action:s`[%receive (silt ~[txn.write])])
+            :-  %sequencer-town-action
+            !>(`town-action:s`[%receive (silt ~[txn.write])])
           %+  fact:io
             [%write-result !>(`write-result:u`[%sent ~])]
           ~[/track/[txn-hash]]
@@ -319,13 +319,13 @@
         ::
             %thread-done
           ?:  =(*vase q.cage.sign)  `this  ::  thread canceled
-          =*  shard    p.u.source
+          =*  town    p.u.source
           =*  d        q.u.source
           =/  is-last-ping-tid=?  =(0 ~(wyt by ping-tids))
           =.  indexer-sources-ping-results
-            %+  ~(put by indexer-sources-ping-results)  shard
+            %+  ~(put by indexer-sources-ping-results)  town
             =/  [pu=(set dock) pd=(set dock) nu=(set dock) nd=(set dock)]
-              %+  ~(gut by indexer-sources-ping-results)  shard
+              %+  ~(gut by indexer-sources-ping-results)  town
               [~ ~ ~ ~]
             =:  nu  ?:(!<(? q.cage.sign) (~(put in nu) d) nu)
                 nd  ?:(!<(? q.cage.sign) nd (~(put in nd) d))
@@ -384,7 +384,7 @@
           max-ping-time
         =.  indexer-sources-ping-results
           %-  ~(urn by indexer-sources-ping-results)
-          |=  $:  shard=@ux
+          |=  $:  town=@ux
                   previous-up=(set dock)
                   previous-down=(set dock)
                   newest-up=(set dock)
@@ -402,29 +402,29 @@
         =/  until=@da  (slav %da i.t.wire)
         ?:  (gth until now.bowl)  `this
         =.  indexer-sources-ping-results
-          =/  ping-tids-list=(list [@ta shard=id:smart d=dock])
+          =/  ping-tids-list=(list [@ta town=id:smart d=dock])
             ~(tap by ping-tids)
           |-
           ?~  ping-tids-list
             %-  ~(gas by *_indexer-sources-ping-results)
             %+  turn  ~(tap by indexer-sources-ping-results)
-            |=  $:  shard=id:smart
+            |=  $:  town=id:smart
                     (set dock)
                     (set dock)
                     newest-up=(set dock)
                     newest-down=(set dock)
                 ==
-            [shard newest-up newest-down ~ ~]
-          =*  shard  shard.i.ping-tids-list
+            [town newest-up newest-down ~ ~]
+          =*  town  town.i.ping-tids-list
           =*  d      d.i.ping-tids-list
           %=  $
               ping-tids-list  t.ping-tids-list
               indexer-sources-ping-results
             =/  [pu=(set dock) pd=(set dock) nu=(set dock) nd=(set dock)]
               %+  ~(gut by indexer-sources-ping-results)
-              shard  [~ ~ ~ ~]
+              town  [~ ~ ~ ~]
             %+  ~(put by indexer-sources-ping-results)
-            shard  [pu pd nu (~(put in nd) d)]
+            town  [pu pd nu (~(put in nd) d)]
           ==
         :-  %-  zing
             :-  move-downed-subscriptions
@@ -446,7 +446,7 @@
       ^-  (list card)
       %-  zing
       %+  turn  ~(tap by indexer-sources-ping-results)
-      |=  $:  shard=id:smart
+      |=  $:  town=id:smart
               previous-up=(set dock)
               previous-down=(set dock)
               newest-up=(set dock)
@@ -456,7 +456,7 @@
       |=  [[[w=^wire s=ship t=term] a=? p=path] out=(list card)]
       ?.  (~(has in previous-down) [s t])
         out
-      ?~  source=(get-best-source:uc shard ~ %nu)  out
+      ?~  source=(get-best-source:uc town ~ %nu)  out
       :+  (~(leave pass:io w) [s t])
         %+  ~(watch pass:io w)  p.u.source
         ?.(?=(%history (rear p)) p (snip p))
@@ -469,9 +469,9 @@
       =/  all-indexer-sources=(list (pair id:smart dock))
         %-  zing
         %+  turn  ~(tap by indexer-sources)
-        |=  [shard=id:smart docks=(set dock)]
+        |=  [town=id:smart docks=(set dock)]
         %+  turn  ~(tap in docks)
-        |=(d=dock [shard d])
+        |=(d=dock [town d])
       |-
       ?~  all-indexer-sources
         =.  pings-timedout  `(add now.bowl ping-timeout)
@@ -481,14 +481,14 @@
             %~  wait  pass:io
             /ping-timeout/(scot %da u.pings-timedout)
         cards
-      =*  shard  p.i.all-indexer-sources
+      =*  town  p.i.all-indexer-sources
       =*  d      q.i.all-indexer-sources
       =/  tid=@ta
         %+  rap  3
         :~  'ted-'
             (scot %uw (sham eny.bowl))
             '-'
-            (scot %ux shard)
+            (scot %ux town)
             '-'
             (scot %p p.d)
         ==
@@ -551,7 +551,7 @@
     ::
         %indexer
       ::  must be of the form, e.g.,
-      ::   /indexer/[requesting-app-name]/grain/[shard-id]/[grain-id]
+      ::   /indexer/[requesting-app-name]/grain/[town-id]/[grain-id]
       ?.  ?=([%indexer @ @ @ @ ~] path)  ~
       leave-indexer
     ==
@@ -613,7 +613,7 @@
   `[[s.wex t.wex] p.wex]
 ::
 ++  get-best-source
-  |=  [shard=id:smart seen=(list @ud) level=?(%nu %nd %pu %pd %~)]
+  |=  [town=id:smart seen=(list @ud) level=?(%nu %nd %pu %pd %~)]
   ^-  (unit [p=dock q=(list @ud) r=?(%nu %nd %pu %pd %~)])
   ::  TODO:
   ::   temporary hack to reduce fragility, since the
@@ -634,32 +634,32 @@
   :: ::
   :: ++  get-best-source-inner
   ::   ^-  (unit [p=(unit dock) q=(list @ud) r=?(%nu %nd %pu %pd %~)])
-  ::   =+  shard-spr=(~(get by indexer-sources-ping-results) shard-id)
-  ::   =+  shard-s=(~(get ju indexer-sources) shard-id)
-  ::   ?~  shard-spr
-  ::     =/  size-shard-s=@ud  ~(wyt in shard-s)
-  ::     ?:  =(0 size-shard-s)  ~
+  ::   =+  town-spr=(~(get by indexer-sources-ping-results) town-id)
+  ::   =+  town-s=(~(get ju indexer-sources) town-id)
+  ::   ?~  town-spr
+  ::     =/  size-town-s=@ud  ~(wyt in town-s)
+  ::     ?:  =(0 size-town-s)  ~
   ::     =^  index  seen
-  ::       (roll-without-replacement size-shard-s seen)
-  ::     `[`(snag index ~(tap in shard-s)) seen %~]
-  ::   =/  [level-shard-spr=(set dock) next-level=?(%nu %nd %pu %pd %~)]
-  ::     =*  newest-up    newest-up.u.shard-spr
-  ::     =*  newest-down  newest-down.u.shard-spr
+  ::       (roll-without-replacement size-town-s seen)
+  ::     `[`(snag index ~(tap in town-s)) seen %~]
+  ::   =/  [level-town-spr=(set dock) next-level=?(%nu %nd %pu %pd %~)]
+  ::     =*  newest-up    newest-up.u.town-spr
+  ::     =*  newest-down  newest-down.u.town-spr
   ::     =/  newest-seen-so-far=(set dock)
   ::       (~(uni in newest-up) newest-down)
   ::     ?+    level  !!  ::  TODO: handle better?
   ::         %nu
   ::       :-  newest-up
   ::       ?:  (gth ~(wyt in newest-up) (lent seen))  level
-  ::       ?:(=(shard-s newest-seen-so-far) %nd %pu)
+  ::       ?:(=(town-s newest-seen-so-far) %nd %pu)
   ::     ::
   ::         %pu
-  ::       =*  previous-up  previous-up.u.shard-spr
+  ::       =*  previous-up  previous-up.u.town-spr
   ::       :-  (~(dif in previous-up) newest-seen-so-far)
   ::       ?:((gth ~(wyt in previous-up) (lent seen)) level %pd)
   ::     ::
   ::         %pd
-  ::       =*  previous-down  previous-down.u.shard-spr
+  ::       =*  previous-down  previous-down.u.town-spr
   ::       :-  (~(dif in previous-down) newest-seen-so-far)
   ::       ?:((gth ~(wyt in previous-down) (lent seen)) level %nd)
   ::     ::
@@ -667,11 +667,11 @@
   ::       :-  newest-down
   ::       ?:((gth ~(wyt in newest-down) (lent seen)) level %~)
   ::     ==
-  ::   =/  size-level-shard-spr=@ud  ~(wyt in level-shard-spr)
-  ::   ?:  =(0 size-level-shard-spr)  `[~ seen next-level]
+  ::   =/  size-level-town-spr=@ud  ~(wyt in level-town-spr)
+  ::   ?:  =(0 size-level-town-spr)  `[~ seen next-level]
   ::   =^  index  seen
-  ::     (roll-without-replacement size-level-shard-spr seen)
-  ::   :^  ~  `(snag index ~(tap in level-shard-spr))
+  ::     (roll-without-replacement size-level-town-spr seen)
+  ::   :^  ~  `(snag index ~(tap in level-town-spr))
   ::   ?.(=(level next-level) ~ seen)  next-level
   :: --
 --

--- a/app/ziggurat.hoon
+++ b/app/ziggurat.hoon
@@ -200,7 +200,7 @@
             id=q
             source=0x0
             holder=user-address.project
-            shard-id=designated-shard-id
+            town-id=designated-town-id
             code=p.r
             interface=~
             types=~
@@ -221,10 +221,10 @@
         %add-to-state
       =/  =project  (~(got by projects) project.act)
       =/  data-text  ;;(@t noun.act)
-      =/  =id:smart  (hash-data:smart source.act holder.act shard-id.act salt.act)
+      =/  =id:smart  (hash-data:smart source.act holder.act town-id.act salt.act)
       =/  =data:smart
         =+  (text-to-zebra-noun data-text smart-lib-vase)
-        [id source.act holder.act shard-id.act salt.act label.act -]
+        [id source.act holder.act town-id.act salt.act label.act -]
       ::  take text data input and ream to form data noun
       ::  put a new grain in the granary
       =:  p.chain.project
@@ -272,9 +272,9 @@
       =/  =project  (~(got by projects) project.act)
       ?~  current=(~(get by tests.project) test-id.act)
         ~|("%ziggurat: test does not exist" !!)
-      =/  =id:smart  (hash-data:smart source.act holder.act shard-id.act salt.act)
+      =/  =id:smart  (hash-data:smart source.act holder.act town-id.act salt.act)
       =/  =data:smart
-        [id source.act holder.act shard-id.act salt.act label.act noun.act]
+        [id source.act holder.act town-id.act salt.act label.act noun.act]
       =/  tex  ;;(@t noun.data)
       =/  new
         =-  [id.data %&^data(noun -) tex]
@@ -343,12 +343,12 @@
             ~
             for-contract.test
             gas=[rate.act bud.act]
-            designated-shard-id
+            designated-town-id
             status=0
         ==
       =/  =single-result:engine
         %+  %~  run-single  eng
-            [caller designated-shard-id batch-num.project 0]
+            [caller designated-town-id batch-num.project 0]
           chain.project
         [[0 0 0] action.test shell]
       =/  =expected-diff
@@ -414,7 +414,7 @@
               ~
               for-contract.test
               gas=[rate bud]
-              designated-shard-id
+              designated-town-id
               status=0
           ==
         :_  +(nonce)
@@ -422,7 +422,7 @@
         [[0 0 0] action.test shell]
       =/  [res=state-transition:engine *]
         %^    %~  run  eng
-              [(designated-caller user-address.project 0) designated-shard-id batch-num.project 0]
+              [(designated-caller user-address.project 0) designated-town-id batch-num.project 0]
             chain.project
           (silt eggs)
         256
@@ -462,7 +462,7 @@
     ::
         %deploy-contract
       ::  this will call %wallet agent with a custom constructed %publish call
-      ::  will fail if chosen testnet+shard combo doesn't exist or doesn't have
+      ::  will fail if chosen testnet+town combo doesn't exist or doesn't have
       ::  the publish.hoon contract deployed.
       ::
       =/  =project  (~(got by projects) project.act)
@@ -471,7 +471,7 @@
       ~&  >  "%ziggurat: deploying contract to {<deploy-location.act>} testnet"
       =/  pok
         :*  %transaction  from=address.act
-            contract=0x1111.1111  shard=shard-id.act
+            contract=0x1111.1111  town=town-id.act
             action=[%noun [%deploy upgradable.act .^(noun %ct path.act) ~ ~]]
         ==
       :_  state

--- a/con/lib/fungible.hoon
+++ b/con/lib/fungible.hoon
@@ -130,9 +130,9 @@
     =.  balance.noun.giver  (sub balance.noun.giver amount.act)
     ?~  to-account.act
       ::  if receiver doesn't have an account, try to produce one for them
-      =/  =id  (hash-data this.context to.act shard.context salt.giver)
+      =/  =id  (hash-data this.context to.act town.context salt.giver)
       =+  [amount.act ~ metadata.noun.giver 0]
-      =+  receiver=[id this.context to.act shard.context salt.giver %account -]
+      =+  receiver=[id this.context to.act town.context salt.giver %account -]
       `(result [%&^giver ~] [%&^receiver ~] ~ ~)
     ::  otherwise, add amount given to the existing account for that address
     =+  (need (scry-state u.to-account.act))
@@ -160,9 +160,9 @@
     ==
     ?~  to-account.act
       ::  if receiver doesn't have an account, try to produce one for them
-      =/  =id  (hash-data this.context to.act shard.context salt.giver)
+      =/  =id  (hash-data this.context to.act town.context salt.giver)
       =+  [amount.act ~ metadata.noun.giver 0]
-      =+  receiver=[id this.context to.act shard.context salt.giver %account -]
+      =+  receiver=[id this.context to.act town.context salt.giver %account -]
       `(result [%&^giver ~] [%&^receiver ~] ~ ~)
     ::  otherwise, add amount given to the existing account for that address
     =+  (need (scry-state u.to-account.act))
@@ -186,7 +186,7 @@
     =/  giver=account:sur  noun:(husk account:sur giv `this.context ~)
     ::  reconstruct the typed message and hash
     =/  =typed-message
-      :-  (hash-data this.context holder.p.giv shard.context salt.p.giv)
+      :-  (hash-data this.context holder.p.giv town.context salt.p.giv)
       (sham [holder.p.giv to.act amount.act nonce.act deadline.act])
     =/  signed-hash  (sham typed-message)
     ::  recover the address from the message and signature
@@ -208,9 +208,9 @@
     ?~  to-account.act
     ::  create new `data` for reciever and add it to state
       ::  if receiver doesn't have an account, try to produce one for them
-      =/  =id  (hash-data this.context to.act shard.context salt.p.giv)
+      =/  =id  (hash-data this.context to.act town.context salt.p.giv)
       =+  [amount.act ~ metadata.giver 0]
-      =+  rec=[id this.context to.act shard.context salt.p.giv %account -]
+      =+  rec=[id this.context to.act town.context salt.p.giv %account -]
       `(result [giv ~] [%&^rec ~] ~ ~)
     ::  direct send
     =/  rec=item  (need (scry-state u.to-account.act))
@@ -259,9 +259,9 @@
         (gte u.cap.noun.meta new-supply)
     ?~  account.m
       ::  create new account for receiver
-      =/  =id  (hash-data this.context to.m shard.context salt.noun.meta)
+      =/  =id  (hash-data this.context to.m town.context salt.noun.meta)
       =+  [amount.m ~ token.act 0]
-      =+  rec=[id this.context to.m shard.context salt.noun.meta %account -]
+      =+  rec=[id this.context to.m town.context salt.noun.meta %account -]
       %=  $
         mints.act         t.mints.act
         supply.noun.meta  new-supply
@@ -294,7 +294,7 @@
           salt
       ==
     =/  metadata-id
-      (hash-data this.context this.context shard.context salt)
+      (hash-data this.context this.context town.context salt)
     ::  issue metadata item and mint
     ::  for initial distribution, if any
     =|  issued=(list item)
@@ -302,7 +302,7 @@
     ?~  initial-distribution.act
       ::  finished minting
       =/  metadata-data
-        :*  metadata-id  this.context  this.context  shard.context
+        :*  metadata-id  this.context  this.context  town.context
             salt
             %token-metadata
             token-metadata
@@ -313,9 +313,9 @@
     ?>  ?~  cap.token-metadata  %.y
         (gte u.cap.token-metadata new-supply)
     ::  create new account for receiver
-    =/  =id  (hash-data this.context to.m shard.context salt.token-metadata)
+    =/  =id  (hash-data this.context to.m town.context salt.token-metadata)
     =+  [amount.m ~ metadata-id 0]
-    =+  rec=[id this.context to.m shard.context salt.token-metadata %account -]
+    =+  rec=[id this.context to.m town.context salt.token-metadata %account -]
     %=  $
       supply.token-metadata     new-supply
       issued                    [%&^rec issued]

--- a/con/lib/multisig.hoon
+++ b/con/lib/multisig.hoon
@@ -5,7 +5,7 @@
   ::  calls is hashed to form proposal's key in pending map
   ::  this hash is used to vote on that proposal
   +$  proposal
-    $:  calls=(list [to=id shard=id =yolk])
+    $:  calls=(list [to=id town=id =yolk])
         votes=(pmap address ?)
         ayes=@ud
         nays=@ud
@@ -22,7 +22,7 @@
         [%create threshold=@ud members=(pset address)]
         ::
         [%vote multisig=id proposal-hash=@ux aye=?]
-        [%propose multisig=id calls=(list [to=id shard=id =yolk])]
+        [%propose multisig=id calls=(list [to=id town=id =yolk])]
         ::  the following must be sent by the contract, which means
         ::  that they can only be executed by a successful proposal!
         [%add-member multisig=id =address]

--- a/con/lib/nft.hoon
+++ b/con/lib/nft.hoon
@@ -166,11 +166,11 @@
     ::  unique salt for each item in collection
     =*  m  i.mints.act
     =/  salt    (cat 3 salt.meta (scot %ud next-item-id))
-    =/  new-id  (hash-data this.context to.m shard.context salt)
+    =/  new-id  (hash-data this.context to.m town.context salt)
     ::  properties must match those in metadata spec!
     ?>  =(properties.noun.meta ~(key py properties.m))
     =/  nft-noun  [next-item-id uri.m id.meta ~ properties.m transferrable.m]
-    =/  =data     [new-id this.context to.m shard.context salt %nft nft-noun]
+    =/  =data     [new-id this.context to.m town.context salt %nft nft-noun]
     %=  $
       mints.act     t.mints.act
       next-item-id  +(next-item-id)
@@ -193,13 +193,13 @@
           id.caller.context
           salt.act
       ==
-    =/  =id    (hash-data this.context this.context shard.context salt.act)
-    =/  =data  [id this.context this.context shard.context salt.act %metadata metadata]
+    =/  =id    (hash-data this.context this.context town.context salt.act)
+    =/  =data  [id this.context this.context town.context salt.act %metadata metadata]
     ?~  initial-distribution.act
       `(result ~ [[%& data] ~] ~ ~)
     ::  perform optional mint
     =/  next  [%mint id initial-distribution.act]
-    :-  [this.context shard.context next]^~
+    :-  [this.context town.context next]^~
     (result ~ [[%& data] ~] ~ ~)
   ::
   ::

--- a/con/lib/zigs.hoon
+++ b/con/lib/zigs.hoon
@@ -6,7 +6,7 @@
 ++  sur
   |%
   +$  token-metadata
-    ::  will be automatically inserted into shard state
+    ::  will be automatically inserted into town state
     ::  at instantiation, along with this contract
     ::  hardcoded values included to match token standard
     $:  name=@t

--- a/con/mill-tester.hoon
+++ b/con/mill-tester.hoon
@@ -8,7 +8,7 @@
 ::  :*  0x9999
 ::      0xeeee.eeee
 ::      holder-1:zigs
-::      shard-id
+::      town-id
 ::      [%& `@`'some-salt' %some-label ['some' 'random' 'data']]
 ::  ==
 ::
@@ -18,10 +18,10 @@
   |=  inp=embryo
   ^-  chick
   =/  grain-id=id
-    (fry-rice me.cart id.from.cart shard-id.cart 'salt')
+    (fry-rice me.cart id.from.cart town-id.cart 'salt')
   =/  new-grain=grain
     =+  [%& 'salt' %label 'data']
-    [grain-id me.cart id.from.cart shard-id.cart -]
+    [grain-id me.cart id.from.cart town-id.cart -]
   ?+    -.action.inp  !!
       %change-nonexistent
     (result [new-grain ~] ~ ~ ~)

--- a/con/multisig.hoon
+++ b/con/multisig.hoon
@@ -31,14 +31,14 @@
     ::  must have at least one member
     ?>  ?=(^ members.act)
     ::  no salt -- this contract creates a single grain.
-    =/  =id  (fry-rice me.cart me.cart shard-id.cart 0)
+    =/  =id  (fry-rice me.cart me.cart town-id.cart 0)
     =/  =grain
       :*  %&  0  %multisig
           [members.act threshold.act ~]
           id
           lord=me.cart
           holder=me.cart
-          shard-id.cart
+          town-id.cart
       ==
     (result ~ grain^~ ~ ~)
   ::  all other calls require multisig ID in action
@@ -86,7 +86,7 @@
     ::  this multisig -- this is so other multisigs
     ::  can't change each others' properties
     ?>  %+  levy  calls.act
-        |=  [to=id shard=id =yolk]
+        |=  [to=id town=id =yolk]
         ?.  =(to me.cart)  %.y
         ?.  ?=(?(%add-member %remove-member %set-threshold) p.yolk)  %.y
         =(-.q.yolk multisig.act)

--- a/con/publish.hoon
+++ b/con/publish.hoon
@@ -2,7 +2,7 @@
 ::
 ::  Smart contract that processes deployment and upgrades
 ::  for other smart contracts. Automatically (?) inserted
-::  on any shard that wishes to allow contract production.
+::  on any town that wishes to allow contract production.
 ::
 /+  *zig-sys-smart
 /=  pub  /con/lib/publish
@@ -16,10 +16,10 @@
     =/  source=id  ?:(mutable.act this.context 0x0)
     =/  pact=item
       :*  %|
-          (hash-pact source id.caller.context shard.context code.act)
+          (hash-pact source id.caller.context town.context code.act)
           source
           id.caller.context
-          shard.context
+          town.context
           code.act
           interface.act
           types.act

--- a/con/zigs.hoon
+++ b/con/zigs.hoon
@@ -25,9 +25,9 @@
     =.  balance.noun.giver  (sub balance.noun.giver amount.act)
     ?~  to-account.act
       ::  if receiver doesn't have an account, try to produce one for them
-      =/  =id  (hash-data this.context to.act shard.context salt.giver)
+      =/  =id  (hash-data this.context to.act town.context salt.giver)
       =+  [amount.act ~ metadata.noun.giver 0]
-      =+  receiver=[id this.context to.act shard.context salt.giver %account -]
+      =+  receiver=[id this.context to.act town.context salt.giver %account -]
       `(result [%&^giver ~] [%&^receiver ~] ~ ~)
     ::  otherwise, add amount given to the existing account for that address
     =+  (need (scry-state u.to-account.act))
@@ -51,9 +51,9 @@
     ==
     ?~  to-account.act
       ::  if receiver doesn't have an account, try to produce one for them
-      =/  =id  (hash-data this.context to.act shard.context salt.giver)
+      =/  =id  (hash-data this.context to.act town.context salt.giver)
       =+  [amount.act ~ metadata.noun.giver 0]
-      =+  receiver=[id this.context to.act shard.context salt.giver %account -]
+      =+  receiver=[id this.context to.act town.context salt.giver %account -]
       `(result [%&^giver ~] [%&^receiver ~] ~ ~)
     ::  otherwise, add amount given to the existing account for that address
     =+  (need (scry-state u.to-account.act))

--- a/gen/sequencer/batch.hoon
+++ b/gen/sequencer/batch.hoon
@@ -1,4 +1,4 @@
 :-  %say
 |=  [[now=@da eny=@uvJ bek=beak] ~ ~]
-:-  %sequencer-shard-action
+:-  %sequencer-town-action
 [%trigger-batch ~]

--- a/gen/sequencer/init.hoon
+++ b/gen/sequencer/init.hoon
@@ -9,16 +9,16 @@
 /*  publish-contract   %jam  /con/compiled/publish/jam
 /*  zigs-contract      %jam  /con/compiled/zigs/jam
 :-  %say
-|=  [[now=@da eny=@uvJ bek=beak] [rollup-host=@p shard-id=@ux private-key=@ux ~] ~]
+|=  [[now=@da eny=@uvJ bek=beak] [rollup-host=@p town-id=@ux private-key=@ux ~] ~]
 ::  one hundred million testnet zigs, now and forever
 =/  testnet-zigs-supply  100.000.000.000.000.000.000.000.000
 ::
 =/  pubkey-1  0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70
 =/  pubkey-2  0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de
 =/  pubkey-3  0x25a8.eb63.a5e7.3111.c173.639b.68ce.091d.d3fc.f139
-=/  zigs-1  (hash-data:smart zigs-contract-id:smart pubkey-1 shard-id `@`'zigs')
-=/  zigs-2  (hash-data:smart zigs-contract-id:smart pubkey-2 shard-id `@`'zigs')
-=/  zigs-3  (hash-data:smart zigs-contract-id:smart pubkey-3 shard-id `@`'zigs')
+=/  zigs-1  (hash-data:smart zigs-contract-id:smart pubkey-1 town-id `@`'zigs')
+=/  zigs-2  (hash-data:smart zigs-contract-id:smart pubkey-2 town-id `@`'zigs')
+=/  zigs-3  (hash-data:smart zigs-contract-id:smart pubkey-3 town-id `@`'zigs')
 ::
 =/  beef-zigs-item
   ^-  item:smart
@@ -26,7 +26,7 @@
       zigs-1
       zigs-contract-id:smart
       pubkey-1
-      shard-id
+      town-id
       `@`'zigs'
       %account
       [300.000.000.000.000.000.000 ~ `@ux`'zigs-metadata' 0]
@@ -37,7 +37,7 @@
       zigs-2
       zigs-contract-id:smart
       pubkey-2
-      shard-id
+      town-id
       `@`'zigs'
       %account
       [200.000.000.000.000.000.000 ~ `@ux`'zigs-metadata' 0]
@@ -48,7 +48,7 @@
       zigs-3
       zigs-contract-id:smart
       pubkey-3
-      shard-id
+      town-id
       `@`'zigs'
       %account
       [100.000.000.000.000.000.000 ~ `@ux`'zigs-metadata' 0]
@@ -59,7 +59,7 @@
   :*  `@ux`'zigs-metadata'
       zigs-contract-id:smart
       zigs-contract-id:smart
-      shard-id
+      town-id
       `@`'zigs'
       %token-metadata
       :*  name='UQ| Tokens'
@@ -79,7 +79,7 @@
   :*  zigs-contract-id:smart  ::  id
       zigs-contract-id:smart  ::  source
       zigs-contract-id:smart  ::  holder
-      shard-id                ::  shard-id
+      town-id                ::  town-id
       [- +]:(cue zigs-contract)
       interface=interface-json:zigs
       types=types-json:zigs
@@ -90,7 +90,7 @@
   :*  0x1111.1111  ::  id
       0x0          ::  source
       0x0          ::  holder
-      shard-id     ::  shard-id
+      town-id     ::  town-id
       [- +]:(cue publish-contract)
       interface=interface-json:publish
       types=~
@@ -99,10 +99,10 @@
 =/  nft-pact
   ^-  pact:smart
   =/  code  (cue nft-contract)
-  :*  (hash-pact:smart 0x0 0x0 shard-id code)
+  :*  (hash-pact:smart 0x0 0x0 town-id code)
       0x0          ::  source
       0x0          ::  holder
-      shard-id     ::  shard-id
+      town-id     ::  town-id
       [- +]:code
       interface=interface-json:nft
       types=types-json:nft
@@ -115,7 +115,7 @@
   :*  id=`@ux`'nft-metadata'
       source=id:nft-pact
       holder=id:nft-pact
-      shard-id
+      town-id
       salt=`@`'nftsalt'
       label=%metadata
       :*  name='Ziggurat Girls'
@@ -129,13 +129,13 @@
           salt=`@`'nftsalt'
       ==
   ==
-=/  nft-1  (hash-data:smart id:nft-pact pubkey-1 shard-id `@`'nftsalt1')
+=/  nft-1  (hash-data:smart id:nft-pact pubkey-1 town-id `@`'nftsalt1')
 =/  nft-data
   ^-  data:smart
   :*  nft-1
       id:nft-pact
       pubkey-1
-      shard-id
+      town-id
       salt=`@`'nftsalt1'
       label=%nft
       :*  1
@@ -151,10 +151,10 @@
 =/  fungible-pact
   ^-  pact:smart
   =/  code  (cue fungible-contract)
-  :*  (hash-pact:smart 0x0 0x0 shard-id code)
+  :*  (hash-pact:smart 0x0 0x0 town-id code)
       0x0          ::  source
       0x0          ::  holder
-      shard-id      ::  shard-id
+      town-id      ::  town-id
       [- +]:code
       interface=interface-json:fungible
       types=types-json:fungible
@@ -176,13 +176,13 @@
       [id.zigs-metadata [%& zigs-metadata]]
   ==
 ::
-:-  %sequencer-shard-action
-^-  shard-action
+:-  %sequencer-town-action
+^-  town-action
 :*  %init
     rollup-host
     (address-from-prv:key:ethereum private-key)
     private-key
-    shard-id
+    town-id
     `[fake-state ~]
     [%full-publish ~]
 ==

--- a/gen/uqbar/set-sources.hoon
+++ b/gen/uqbar/set-sources.hoon
@@ -1,11 +1,11 @@
 /-  *zig-uqbar
 :-  %say
-|=  [[now=@da eny=@uvJ bek=beak] [shard-id=@ux indexers=(list @p) ~] ~]
+|=  [[now=@da eny=@uvJ bek=beak] [town-id=@ux indexers=(list @p) ~] ~]
 :-  %uqbar-action
 ^-  action
 :-  %set-sources
 :_  ~
-:-  shard-id
+:-  town-id
 %-  ~(gas in *(set dock))
 %+  turn  indexers
 |=(indexer=@p [indexer %indexer])

--- a/lib/zig/indexer.hoon
+++ b/lib/zig/indexer.hoon
@@ -83,18 +83,18 @@
       (frond %newest-item (newest-item +.update))
     ==
   ::
-  ++  shard-location
-    |=  =shard-location:ui
+  ++  town-location
+    |=  =town-location:ui
     ^-  json
     %-  pairs
-    :-  [%shard-id %s (scot %ux shard-location)]
+    :-  [%town-id %s (scot %ux town-location)]
     ~
   ::
   ++  batch-location
     |=  =batch-location:ui
     ^-  json
     %-  pairs
-    :+  [%shard-id %s (scot %ux shard-id.batch-location)]
+    :+  [%town-id %s (scot %ux town-id.batch-location)]
       [%batch-root %s (scot %ux batch-root.batch-location)]
     ~
   ::
@@ -102,31 +102,31 @@
     |=  =txn-location:ui
     ^-  json
     %-  pairs
-    :^    [%shard-id %s (scot %ux shard-id.txn-location)]
+    :^    [%town-id %s (scot %ux town-id.txn-location)]
         [%batch-root %s (scot %ux batch-root.txn-location)]
       [%txn-num (numb txn-num.txn-location)]
     ~
   ::
   ++  batches
-    |=  batches=(map batch-id=id:smart [@da shard-location:ui batch:ui])
+    |=  batches=(map batch-id=id:smart [@da town-location:ui batch:ui])
     ^-  json
     %-  pairs
     %+  turn  ~(tap by batches)
-    |=  [=id:smart timestamp=@da location=shard-location:ui b=batch:ui]
+    |=  [=id:smart timestamp=@da location=town-location:ui b=batch:ui]
     :-  (scot %ux id)
     %-  pairs
     :^    [%timestamp (sect timestamp)]
-        [%location (shard-location location)]
+        [%location (town-location location)]
       [%batch (batch b)]
     ~
   ::
   ++  newest-batch
-    |=  [=id:smart timestamp=@da location=shard-location:ui b=batch:ui]
+    |=  [=id:smart timestamp=@da location=town-location:ui b=batch:ui]
     ^-  json
     %-  pairs
     :-  [%batch-id %s (scot %ux id)]
     :^    [%timestamp (sect timestamp)]
-        [%location (shard-location location)]
+        [%location (town-location location)]
       [%batch (batch b)]
     ~
   ::
@@ -135,7 +135,7 @@
     ^-  json
     %-  pairs
     :+  [%transactions (transactions transactions.batch)]
-      [%shard (shard +.batch)]
+      [%town (town +.batch)]
     ~
   ::
   ++  transactions
@@ -190,7 +190,7 @@
         [%contract %s (scot %ux contract.shell)]
         [%rate (numb rate.gas.shell)]
         [%budget (numb bud.gas.shell)]
-        [%shard-id %s (scot %ux shard.shell)]
+        [%town-id %s (scot %ux town.shell)]
         [%status (numb status.shell)]
     ==
   ::
@@ -286,15 +286,15 @@
     :~  [%id %s (scot %ux id.p.item)]
         [%source %s (scot %ux source.p.item)]
         [%holder %s (scot %ux holder.p.item)]
-        [%shard %s (scot %ux shard.p.item)]
+        [%town %s (scot %ux town.p.item)]
     ==
   ::
-  ++  shard
-    |=  =shard:seq
+  ++  town
+    |=  =town:seq
     ^-  json
     %-  pairs
-    :+  [%chain (chain chain.shard)]
-      [%hall (hall hall.shard)]
+    :+  [%chain (chain chain.town)]
+      [%hall (hall hall.town)]
     ~
   ::
   ++  chain
@@ -327,7 +327,7 @@
     |=  =hall:seq
     ^-  json
     %-  pairs
-    :~  [%shard-id %s (scot %ux shard-id.hall)]
+    :~  [%town-id %s (scot %ux town-id.hall)]
         [%sequencer (sequencer sequencer.hall)]
         [%mode (mode mode.hall)]
         [%latest-diff-hash %s (scot %ux latest-diff-hash.hall)]

--- a/lib/zig/sequencer.hoon
+++ b/lib/zig/sequencer.hoon
@@ -2,8 +2,8 @@
 /+  engine=zig-sys-engine
 |%
 ++  transition-state
-  |=  [old=(unit shard) proposed=[num=@ud =memlist:engine =chain:engine diff-hash=@ux root=@ux]]
-  ^-  (unit shard)
+  |=  [old=(unit town) proposed=[num=@ud =memlist:engine =chain:engine diff-hash=@ux root=@ux]]
+  ^-  (unit town)
   ?~  old  old
   :-  ~
   %=  u.old

--- a/lib/zig/sys/engine.hoon
+++ b/lib/zig/sys/engine.hoon
@@ -43,7 +43,7 @@
   [[q.dor [q.dor-sam q.arm-sam]] q.gun]
 ::
 ++  engine
-  |_  [sequencer=caller:smart shard-id=@ux batch=@ud eth-block-height=@ud]
+  |_  [sequencer=caller:smart town-id=@ux batch=@ud eth-block-height=@ud]
   ::
   ::  +mill-all
   ::
@@ -235,8 +235,8 @@
         %^  gut:big  state  zigs.sequencer
         ::  create a new account rice for the sequencer if needed
         =/  =token-account  [total ~ `@ux`'zigs-metadata' 0]
-        =/  =id:smart  (hash-data:smart zigs-contract-id:smart address.sequencer shard-id `@`'zigs')
-        [%& id zigs-contract-id:smart address.sequencer shard-id 'zigs' %account token-account]
+        =/  =id:smart  (hash-data:smart zigs-contract-id:smart address.sequencer town-id `@`'zigs')
+        [%& id zigs-contract-id:smart address.sequencer town-id 'zigs' %account token-account]
       ?.  ?=(%& -.acc)  state
       =/  account  ;;(token-account noun.p.acc)
       ?.  =(`@ux`'zigs-metadata' metadata.account)  state
@@ -283,7 +283,7 @@
       |=  [=pact:smart txn=transaction:smart hits=(list hints:zink) burned=^state]
       ^-  hatchling
       |^
-      =/  =context:smart  [contract.txn [- +<]:caller.txn batch eth-block-height shard-id]
+      =/  =context:smart  [contract.txn [- +<]:caller.txn batch eth-block-height town-id]
       =+  [hit move rem err]=(exec bud.gas.txn context)
       ?~  move  [hit^hits ~ ~ ~ rem err]
       =*  calls  -.u.move
@@ -448,8 +448,8 @@
               |(=(source source.p.item) =(0x0 source.p.item))
               !(has:big state id.p.item)
               ?:  ?=(%| -.item)
-                =(id (hash-pact:smart source holder.p.item shard.p.item code.p.item))
-              =(id (hash-data:smart source holder.p.item shard.p.item salt.p.item))
+                =(id (hash-pact:smart source holder.p.item town.p.item code.p.item))
+              =(id (hash-data:smart source holder.p.item town.p.item salt.p.item))
           ==
         ::
           %-  ~(all in burned.diff)
@@ -461,7 +461,7 @@
           ::  burned cannot contain item used to pay for gas
           ::
           ::  NOTE: you *can* modify a item in-contract before burning it.
-          ::  the shard-id of a burned item marks the shard which can REDEEM it.
+          ::  the town-id of a burned item marks the town which can REDEEM it.
           ::
           =/  old  (get:big state id)
           ?&  ?=(^ old)
@@ -474,9 +474,9 @@
       ==
     ::
     ::  +exec-burn: handle special burn-only transactions, used for manually
-    ::  escaping some item from a shard. must be EITHER holder or source to burn.
-    ::  if shard-id is the same as the source shard, the item is burned permanently.
-    ::  otherwise, it can be reinstantiated on the specified shard.
+    ::  escaping some item from a town. must be EITHER holder or source to burn.
+    ::  if town-id is the same as the source town, the item is burned permanently.
+    ::  otherwise, it can be reinstantiated on the specified town.
     ::
     ++  exec-burn
       |=  txn=transaction:smart
@@ -487,8 +487,8 @@
       ::  charge fixed cost for failed transactions too
       ::  TODO should do this everywhere that we can inside +farm
       =/  fail  [~ ~ ~ ~ (sub bud.gas.txn fixed-burn-cost) %6]
-      ::  argument for %burn must be a grain ID and shard ID
-      ?.  ?=([id=@ux shard=@ux] q.calldata.txn)      fail
+      ::  argument for %burn must be a grain ID and town ID
+      ?.  ?=([id=@ux town=@ux] q.calldata.txn)      fail
       ::  item must exist in state
       ?~  to-burn=(get:big state id.q.calldata.txn)  fail
       ::  caller must be source OR holder

--- a/lib/zig/sys/smart.hoon
+++ b/lib/zig/sys/smart.hoon
@@ -43,16 +43,16 @@
 ::  +hash: standard hashing functions for items
 ::
 ++  hash-pact
-  |=  [source=id holder=id shard=id code=*]
+  |=  [source=id holder=id town=id code=*]
   ^-  id
   ^-  @ux  %-  shax
-  :((cury cat 3) shard source holder (sham code))
+  :((cury cat 3) town source holder (sham code))
 ::
 ++  hash-data
-  |=  [source=id holder=id shard=id salt=@]
+  |=  [source=id holder=id town=id salt=@]
   ^-  id
   ^-  @ux  %-  shax
-  :((cury cat 3) shard source holder salt)
+  :((cury cat 3) town source holder salt)
 ::
 ::  +result: generate a diff
 ::
@@ -86,19 +86,19 @@
 +$  item  (each data pact)
 ::
 ::  each piece of data includes a contract-defined salt and label
-::  salt is for hashing, to be combined with source/holder/shard for
+::  salt is for hashing, to be combined with source/holder/town for
 ::  a unique rice ID without needing to jam data. label matches
 ::  types defined in pact and allows apps to find a type
 ::  representation for the contained data.
 ::
 +$  data
-  $:  =id  source=id  holder=id  shard=id
+  $:  =id  source=id  holder=id  town=id
       salt=@  label=@tas
       noun=*
   ==
 ::
 +$  pact
-  $:  =id  source=id  holder=id  shard=id
+  $:  =id  source=id  holder=id  town=id
       code=[bat=* pay=*]
       interface=(map @tas json)
       types=(map @tas json)
@@ -111,7 +111,7 @@
       caller=[=id nonce=@ud]  ::  information about caller
       batch=@ud
       eth-block=@ud
-      shard=id
+      town=id
   ==
 ::
 ::  smart contract definition
@@ -140,7 +140,7 @@
       burned=(merk id item)
       =events
   ==
-+$  call  [contract=id shard=id =calldata]
++$  call  [contract=id town=id =calldata]
 +$  event   (pair @tas json)
 +$  events  (list event)
 ::
@@ -154,7 +154,7 @@
       eth-hash=(unit @)  ::  if signed with eth wallet, use verify signature
       contract=id
       gas=[rate=@ud bud=@ud]
-      shard=id
+      town=id
       status=@ud  ::  error code
   ==
 ::

--- a/lib/zig/wallet.hoon
+++ b/lib/zig/wallet.hoon
@@ -52,10 +52,10 @@
   `[%pass wire %agent [ship term] %leave ~]
 ::
 ++  watch-for-batches
-  |=  [our=@p shard=@ux]
+  |=  [our=@p town=@ux]
   ^-  (list card)
   =-  [%pass /new-batch %agent [our %uqbar] %watch -]~
-  /indexer/wallet/batch-order/(scot %ux shard)/history
+  /indexer/wallet/batch-order/(scot %ux town)/history
 ::
 ++  make-tokens
   |=  [addrs=(list address:smart) our=@p now=@da]
@@ -71,9 +71,9 @@
     =/  single=asset
       ?.  ?=(%& -.item.upd)
         ::  handle contract asset
-        [%unknown shard.p.item.upd source.p.item.upd ~]
+        [%unknown town.p.item.upd source.p.item.upd ~]
       ::  determine type token/nft/unknown
-      (discover-asset-mold shard.p.item.upd source.p.item.upd noun.p.item.upd)
+      (discover-asset-mold town.p.item.upd source.p.item.upd noun.p.item.upd)
       %=  $
         addrs  t.addrs
         new  (~(put by new) i.addrs (malt ~[[id.p.item.upd single]]))
@@ -96,24 +96,24 @@
   =/  =asset
     ?.  ?=(%& -.item)
       ::  handle contract asset
-      [%unknown shard.p.item source.p.item ~]
+      [%unknown town.p.item source.p.item ~]
     ::  determine type token/nft/unknown and store in book
-    (discover-asset-mold shard.p.item source.p.item noun.p.item)
+    (discover-asset-mold town.p.item source.p.item noun.p.item)
   %=  $
     items-list  t.items-list
     new-book  (~(put by new-book) id.p.item asset)
   ==
 ::
 ++  discover-asset-mold
-  |=  [shard=@ux contract=@ux data=*]
+  |=  [town=@ux contract=@ux data=*]
   ^-  asset
   =+  tok=((soft token-account) data)
   ?^  tok
-    [%token shard contract metadata.u.tok u.tok]
+    [%token town contract metadata.u.tok u.tok]
   =+  nft=((soft nft) data)
   ?^  nft
-    [%nft shard contract metadata.u.nft u.nft]
-  [%unknown shard contract data]
+    [%nft town contract metadata.u.nft u.nft]
+  [%unknown town contract data]
 ::
 ++  update-metadata-store
   |=  [tokens=(map address:smart book) =metadata-store our=@p now=@da]
@@ -132,7 +132,7 @@
       ::  (sub to indexer for the metadata item id, update our store on update)
       $(book t.book)
     ::  scry indexer for metadata item and store it
-    ?~  meta=(fetch-metadata -.asset shard.asset metadata.asset our now)
+    ?~  meta=(fetch-metadata -.asset town.asset metadata.asset our now)
       ::  couldn't find it
       $(book t.book)
     %=  $
@@ -146,11 +146,11 @@
   ==
 ::
 ++  fetch-metadata
-  |=  [token-type=@tas shard=@ux =id:smart our=ship now=time]
+  |=  [token-type=@tas town=@ux =id:smart our=ship now=time]
   ^-  (unit asset-metadata)
   ::  manually import metadata for a token
   =/  scry-res
-    .^(update:ui %gx /(scot %p our)/uqbar/(scot %da now)/indexer/newest/item/(scot %ux shard)/(scot %ux id)/noun)
+    .^(update:ui %gx /(scot %p our)/uqbar/(scot %da now)/indexer/newest/item/(scot %ux town)/(scot %ux id)/noun)
   =/  g=(unit item:smart)
     ::  TODO remote scry w/ uqbar.hoon
     ?~  scry-res  ~
@@ -161,8 +161,8 @@
     ~
   ?.  ?=(%& -.u.g)  ~
   ?+  token-type  ~
-    %token  `[%token shard ;;(token-metadata noun.p.u.g)]
-    %nft    `[%nft shard ;;(nft-metadata noun.p.u.g)]
+    %token  `[%token town ;;(token-metadata noun.p.u.g)]
+    %nft    `[%nft town ;;(nft-metadata noun.p.u.g)]
   ==
 ::
 ::  JSON parsing utils
@@ -176,7 +176,7 @@
   :-  (scot %ux id)
   %-  pairs
   :~  ['id' [%s (scot %ux id)]]
-      ['shard' [%s (scot %ux shard.asset)]]
+      ['town' [%s (scot %ux town.asset)]]
       ['contract' [%s (scot %ux contract.asset)]]
       ['token_type' [%s (scot %tas -.asset)]]
       :-  'data'
@@ -207,7 +207,7 @@
   :-  (scot %ux id)
   %-  pairs
   :~  ['id' [%s (scot %ux id)]]
-      ['shard' [%s (scot %ux shard.m)]]
+      ['town' [%s (scot %ux town.m)]]
       ['token_type' [%s (scot %tas -.m)]]
       :-  'data'
       %-  pairs
@@ -259,7 +259,7 @@
       ['contract' [%s (scot %ux contract.t)]]
       ['rate' (numb rate.gas.t)]
       ['budget' (numb bud.gas.t)]
-      ['shard' [%s (scot %ux shard.t)]]
+      ['town' [%s (scot %ux town.t)]]
       ['status' (numb status.t)]
       :-  'action'
       %-  frond

--- a/lib/zig/ziggurat.hoon
+++ b/lib/zig/ziggurat.hoon
@@ -10,7 +10,7 @@
   |=  [=address:smart nonce=@ud]
   ^-  caller:smart
   [address nonce id.p:(designated-zigs-item address)]
-++  designated-shard-id  0x0
+++  designated-town-id  0x0
 ::  we set the designated caller to have 300 zigs
 ++  designated-zigs-item
   |=  =address:smart
@@ -19,12 +19,12 @@
       %:  hash-data:smart
           zigs-contract-id:smart
           address
-          designated-shard-id
+          designated-town-id
           `@`'zigs'
       ==
       zigs-contract-id:smart
       address
-      designated-shard-id
+      designated-town-id
       `@`'zigs'
       %account
       [300.000.000.000.000.000.000 ~ `@ux`'zigs-metadata' 0]
@@ -232,7 +232,7 @@
     %:  hash-data:smart
         source.meta-rice
         user-address.current
-        designated-shard-id
+        designated-town-id
         salt.metadata
     ==
   =/  dead-beef-account
@@ -240,7 +240,7 @@
     :*  dead-beef-account-id
         source.meta-rice
         user-address.current
-        designated-shard-id
+        designated-town-id
         salt.metadata
         %account
         [200 ~ id.meta-rice 0]
@@ -249,7 +249,7 @@
     %:  hash-data:smart
         source.meta-rice
         0xcafe.babe
-        designated-shard-id
+        designated-town-id
         salt.metadata
     ==
   =/  cafe-babe-account
@@ -257,7 +257,7 @@
     :*  cafe-babe-account-id
         source.meta-rice
         0xcafe.babe
-        designated-shard-id
+        designated-town-id
         salt.metadata
         %account
         [100 ~ id.meta-rice 0]
@@ -266,7 +266,7 @@
     %:  hash-data:smart
         source.meta-rice
         0xcafe.d00d
-        designated-shard-id
+        designated-town-id
         salt.metadata
     ==
   =/  cafe-d00d-account
@@ -274,7 +274,7 @@
     :*  cafe-d00d-account-id
         source.meta-rice
         0xcafe.d00d
-        designated-shard-id
+        designated-town-id
         salt.metadata
         %account
         [100 (make-pmap:smart ~[[0xdead.beef 50]]) id.meta-rice 0]
@@ -441,7 +441,7 @@
     %:  hash-data:smart
         source.meta-rice
         user-address.current
-        designated-shard-id
+        designated-town-id
         (cat 3 salt.metadata (scot %ud 1))
     ==
   =/  nft-1
@@ -449,7 +449,7 @@
     :*  nft-1-id
         source.meta-rice
         user-address.current
-        designated-shard-id
+        designated-town-id
         (cat 3 salt.metadata (scot %ud 1))
         %nft
         [1 'https://image.link' id.meta-rice ~ props &]
@@ -465,7 +465,7 @@
     %:  hash-data:smart
         source.meta-rice
         0xcafe.babe
-        designated-shard-id
+        designated-town-id
         (cat 3 salt.metadata (scot %ud 2))
     ==
   =/  nft-2
@@ -473,7 +473,7 @@
     :*  nft-2-id
         source.meta-rice
         0xcafe.babe
-        designated-shard-id
+        designated-town-id
         (cat 3 salt.metadata (scot %ud 2))
         %nft
         [2 'https://image.link' id.meta-rice ~ props &]
@@ -546,7 +546,7 @@
     %:  hash-data:smart
         source.meta-rice
         user-address.current
-        designated-shard-id
+        designated-town-id
         (cat 3 salt.metadata (scot %ud 3))
     ==
   =/  nft-3
@@ -554,7 +554,7 @@
     :*  nft-3-id
         source.meta-rice
         user-address.current
-        designated-shard-id
+        designated-town-id
         (cat 3 salt.metadata (scot %ud 3))
         %nft
         [3 'https://image.link' id.meta-rice ~ props &]
@@ -683,7 +683,7 @@
   %+  welp
     :~  ['source' %s (scot %ux source.p.item)]
         ['holder' %s (scot %ux holder.p.item)]
-        ['shard' %s (scot %ux shard.p.item)]
+        ['town' %s (scot %ux town.p.item)]
     ==
   ?.  ?=(%& -.item)
     ['contract' %b %.y]~

--- a/mar/sequencer/town-action.hoon
+++ b/mar/sequencer/town-action.hoon
@@ -1,14 +1,14 @@
 /-  seq=zig-sequencer
 ::
-|_  =shard-action:seq
+|_  =town-action:seq
 ++  grab
   |%
-  ++  noun  shard-action:seq
+  ++  noun  town-action:seq
   --
 ::
 ++  grow
   |%
-  ++  noun  shard-action
+  ++  noun  town-action
   --
 ::
 ++  grad  %noun

--- a/mar/sequencer/town-update.hoon
+++ b/mar/sequencer/town-update.hoon
@@ -1,14 +1,14 @@
 /-  seq=zig-sequencer
 ::
-|_  =shard-update:seq
+|_  =town-update:seq
 ++  grab
   |%
-  ++  noun  shard-update:seq
+  ++  noun  town-update:seq
   --
 ::
 ++  grow
   |%
-  ++  noun  shard-update
+  ++  noun  town-update
   --
 ::
 ++  grad  %noun

--- a/mar/wallet/poke.hoon
+++ b/mar/wallet/poke.hoon
@@ -47,7 +47,7 @@
       %-  ot
       :~  [%from (se %ux)]
           [%contract (se %ux)]
-          [%shard (se %ux)]
+          [%town (se %ux)]
           [%action parse-action]
       ==
     ++  parse-action

--- a/mar/ziggurat/contract-action.hoon
+++ b/mar/ziggurat/contract-action.hoon
@@ -42,7 +42,7 @@
           [%id (se %ux)]
           [%lord (se %ux)]
           [%holder (se %ux)]
-          [%shard-id (se %ux)]
+          [%town-id (se %ux)]
       ==
     ::
     ++  parse-rice-without-id
@@ -52,7 +52,7 @@
           [%data so]
           [%lord (se %ux)]
           [%holder (se %ux)]
-          [%shard-id (se %ux)]
+          [%town-id (se %ux)]
       ==
     ::
     ++  parse-test
@@ -68,7 +68,7 @@
           [%rate ni]
           [%bud ni]
           [%deploy-location (se %tas)]
-          [%shard-id (se %ux)]
+          [%town-id (se %ux)]
           [%upgradable bo]
       ==
     --

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Ziggurat
 
 Ziggurat is the Uqbar developer suite.
-It contains code for the Gall apps required to simulate the ZK rollup to Ethereum, to sequence transactions in order to run a shard, and the user application suite: the `%wallet` for chain writes, the `%indexer` for chain reads, and `%uqbar`, a unified read-write interface.
+It contains code for the Gall apps required to simulate the ZK rollup to Ethereum, to sequence transactions in order to run a town, and the user application suite: the `%wallet` for chain writes, the `%indexer` for chain reads, and `%uqbar`, a unified read-write interface.
 
 
 ## Contents
@@ -21,7 +21,7 @@ It contains code for the Gall apps required to simulate the ZK rollup to Ethereu
 ![Project Structure](/assets/220901-project-structure.png)
 
 The `%rollup` app simulates the ZK rollup to Ethereum L1.
-The `%sequencer` app runs a shard, receiving transactions from users and batching them up to send to the `%rollup`.
+The `%sequencer` app runs a town, receiving transactions from users and batching them up to send to the `%rollup`.
 The user suite of apps include:
 * `%wallet`: manages key pairs, tracks assets, handles writes to chain
 * `%indexer`: indexes batches, provides a scry interface for chain state, sends subscription updates
@@ -30,10 +30,10 @@ The user suite of apps include:
 The user suite of apps interact with the `%rollup` and `%sequencer` apps, and provide interfaces for use by Urbit apps that need to read or write to the chain.
 
 A single `%rollup` app will be run on a single ship.
-One `%sequencer` app will run each shard.
+One `%sequencer` app will run each town.
 Any ship that interacts with the chain will run the `%wallet`, `%indexer`, and `%uqbar` apps.
 
-In the future, multiple `%sequencer`s may take turns sequencing a single shard.
+In the future, multiple `%sequencer`s may take turns sequencing a single town.
 In the future, with remote scry, users will not need to run their own `%indexer`, and will instead be able to point their `%uqbar` app at a remote `%indexer`.
 
 
@@ -85,7 +85,7 @@ To develop this repo or new contracts, it is convenient to start with a fakeship
 First, make sure the fakeship you're using is in the [whitelist](https://github.com/uqbar-dao/ziggurat/blob/master/lib/rollup.hoon).
 
 Uqbar provides a generator to set up a fakeship testnet for local development.
-That generator, used as a poke to the `%sequencer` app as `:sequencer|init`, populates a new shard with some [`item`](#item)s: [`pact`](#pact) (contract code) and [`data`](#data) (contract data).
+That generator, used as a poke to the `%sequencer` app as `:sequencer|init`, populates a new town with some [`item`](#item)s: [`pact`](#pact) (contract code) and [`data`](#data) (contract data).
 Specifically, contracts for zigs tokens, NFTs, and publishing new contracts are pre-deployed.
 After [initial installation](#initial-installation), start the `%rollup`, initialize the `%sequencer`, set up the `%uqbar` read-write interface, and configure the `%wallet` to point to some [pre-set assets](#accounts-initialized-by-init-script), minted in the `:sequencer|init` poke:
 ```hoon
@@ -108,13 +108,13 @@ First, create a pending transaction.
 The `%wallet` will send the transaction hash on a subscription wire as well as print it in the Dojo.
 ```hoon
 ::  Send zigs tokens.
-:uqbar &wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x74.6361.7274.6e6f.632d.7367.697a shard=0x0 action=[%give to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de amount=123.456 item=0x89a0.89d8.dddf.d13a.418c.0d93.d4b4.e7c7.637a.d56c.96c0.7f91.3a14.8174.c7a7.71e6]]
+:uqbar &wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x74.6361.7274.6e6f.632d.7367.697a town=0x0 action=[%give to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de amount=123.456 item=0x89a0.89d8.dddf.d13a.418c.0d93.d4b4.e7c7.637a.d56c.96c0.7f91.3a14.8174.c7a7.71e6]]
 
 ::  Send an NFT.
-:uqbar &wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x262.52d2.70eb.2e71.d48e.c5c6.1572.c8a9.1a71.2e55.9eaf.af54.d9c0.e3f8.39a5.152a shard=0x0 action=[%give-nft to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de item=0xe61e.c76e.eec9.db7a.5318.c9b1.4896.ed09.d798.2ee0.a79e.9b39.2937.6598.20aa.e239]]
+:uqbar &wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x262.52d2.70eb.2e71.d48e.c5c6.1572.c8a9.1a71.2e55.9eaf.af54.d9c0.e3f8.39a5.152a town=0x0 action=[%give-nft to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de item=0xe61e.c76e.eec9.db7a.5318.c9b1.4896.ed09.d798.2ee0.a79e.9b39.2937.6598.20aa.e239]]
 
 ::  Use the custom transaction interface to send zigs tokens.
-:uqbar &wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x74.6361.7274.6e6f.632d.7367.697a shard=0x0 action=[%noun [%give to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de amount=69.000 from-account=0x89a0.89d8.dddf.d13a.418c.0d93.d4b4.e7c7.637a.d56c.96c0.7f91.3a14.8174.c7a7.71e6 to-account=`0xd79b.98fc.7d3b.d71b.4ac9.9135.ffba.cc6c.6c98.9d3b.8aca.92f8.b07e.a0a5.3d8f.a26c]]]
+:uqbar &wallet-poke [%transaction from=0x7a9a.97e0.ca10.8e1e.273f.0000.8dca.2b04.fc15.9f70 contract=0x74.6361.7274.6e6f.632d.7367.697a town=0x0 action=[%noun [%give to=0xd6dc.c8ff.7ec5.4416.6d4e.b701.d1a6.8e97.b464.76de amount=69.000 from-account=0x89a0.89d8.dddf.d13a.418c.0d93.d4b4.e7c7.637a.d56c.96c0.7f91.3a14.8174.c7a7.71e6 to-account=`0xd79b.98fc.7d3b.d71b.4ac9.9135.ffba.cc6c.6c98.9d3b.8aca.92f8.b07e.a0a5.3d8f.a26c]]]
 ```
 
 Then, sign the transaction and assign it a gas budget.
@@ -129,7 +129,7 @@ Transactions can also be signed using a hardware wallet, via `%submit-signed`.
 ### Submitting a `%batch`
 
 Each signed transaction sent to the `%sequencer` will be stored in the `%sequencer`s `basket` (analogous to a mempool).
-To run the transactions, create the new batch with updated shard state, and send it to the `%rollup`, poke the `%sequencer`:
+To run the transactions, create the new batch with updated town state, and send it to the `%rollup`, poke the `%sequencer`:
 ```hoon
 :sequencer|batch
 ```
@@ -245,15 +245,15 @@ The following two examples assume `~zod` is the host:
 :uqbar|set-sources 0x0 ~[our]
 ```
 In this example, not all the hosts need be the same ship.
-To give a specific example, `~zod` might be running the `%rollup`, while `~bus` runs the `%sequencer` for shard `0x0` and also the `%indexer`.
+To give a specific example, `~zod` might be running the `%rollup`, while `~bus` runs the `%sequencer` for town `0x0` and also the `%indexer`.
 Every user who wishes to interact with the chain must currently run their own `%indexer`, so there will likely be many options to `%indexer-bootstrap` from.
 
 
 ### Sequencing on an existing testnet
 
-To start sequencing a new shard:
+To start sequencing a new town:
 ```hoon
-:sequencer|init ~zod <YOUR_shard_ID> <YOUR_PRIVATE_KEY>
+:sequencer|init ~zod <YOUR_town_ID> <YOUR_PRIVATE_KEY>
 ```
 
 `%sequencer` does not create batches automatically unless configured to do so.
@@ -302,15 +302,15 @@ In general, replace `zigs` with the name of any other contract.
 ## Deploying Contracts to a Running Testnet
 
 Contracts are deployed using the `publish` contract found in this repo at `con/publish.hoon`.
-The `publish` contract is usually deployed on `shard`s in the `pact` with ID `0x1111.1111`.
+The `publish` contract is usually deployed on `town`s in the `pact` with ID `0x1111.1111`.
 For example, to deploy the `multisig` contract, first [compile it](#compiling-contracts-and-the-standard-library).
 Then place it at `con/compiled/multisig.noun`.
-To deploy on shard `0x0`, in the Dojo:
+To deploy on town `0x0`, in the Dojo:
 ```hoon
 =contract-path /=zig=/con/compiled/multisig/jam
 =contract-jam .^(@ %cx contract-path)
 =contract [- +]:(cue contract-jam)
-:uqbar &wallet-poke [%transaction from=[youraddress] contract=0x1111.1111 shard=0x0 action=[%noun [%deploy mutable=%.n cont=contract interface=~ types=~]]]
+:uqbar &wallet-poke [%transaction from=[youraddress] contract=0x1111.1111 town=0x0 action=[%noun [%deploy mutable=%.n cont=contract interface=~ types=~]]]
 ```
 
 
@@ -318,7 +318,7 @@ To deploy on shard `0x0`, in the Dojo:
 
 ### `batch`
 A `batch` in a rollup is analogous to a block in a blockchain.
-`batch`es have a definite order, and are produced by a `%sequencer` for a given `shard`.
+`batch`es have a definite order, and are produced by a `%sequencer` for a given `town`.
 
 
 ### `transaction`
@@ -346,7 +346,7 @@ A `pact` is a piece of code: it is a contract.
 For example, the `zigs` contract that governs the base rollup tokens is a `pact`, and the `nft` contract that enables NFTs to be held and sent is another.
 
 
-### `shard`
+### `town`
 
 A segment of chain-state within the Uqbar rollup.
-A `%sequencer` runs a `shard`, receiving transactions from users, executing them, and then sending the updated state to the `%rollup`.
+A `%sequencer` runs a `town`, receiving transactions from users, executing them, and then sending the updated state to the `%rollup`.

--- a/sur/zig/faucet.hoon
+++ b/sur/zig/faucet.hoon
@@ -2,7 +2,7 @@
 ::
 |%
 +$  action
-  $%  [%open shard-id=id:smart =address:smart]
+  $%  [%open town-id=id:smart =address:smart]
       [%confirm me=address:smart]
   ==
 ::
@@ -10,7 +10,7 @@
   $%  [%edit-gas gas=[rate=@ud budget=@ud]]
       [%edit-volume volume=@ud]
       [%edit-timeout-duration timeout-duration=@dr]
-      [%put-shard shard-id=id:smart =shard-info]
+      [%put-town town-id=id:smart =town-info]
   ==
 ::
 +$  versioned-state
@@ -19,14 +19,14 @@
 ::
 +$  state-0
   $:  %0
-      shard-infos=(map id:smart shard-info)
+      town-infos=(map id:smart town-info)
       gas=[rate=@ud budget=@ud]
       on-timeout=(map @p [unlock=@da count=@ud])
       timeout-duration=@dr
       volume=@ud
   ==
 ::
-+$  shard-info
++$  town-info
   $:  =address:smart
       zigs-account=id:smart
       zigs-contract=id:smart

--- a/sur/zig/indexer.hoon
+++ b/sur/zig/indexer.hoon
@@ -11,25 +11,25 @@
       %holder
       %source
       %to
-      %shard
+      %town
       %hash
   ==
 ::
 +$  query-payload
-  ?(item-hash=@ux [shard-id=@ux item-hash=@ux] location)
+  ?(item-hash=@ux [town-id=@ux item-hash=@ux] location)
 ::
 +$  location
   $?  second-order-location
-      shard-location
+      town-location
       batch-location
       txn-location
   ==
 +$  second-order-location  id:smart
-+$  shard-location  id:smart
++$  town-location  id:smart
 +$  batch-location
-  [shard-id=id:smart batch-root=id:smart]
+  [town-id=id:smart batch-root=id:smart]
 +$  txn-location
-  [shard-id=id:smart batch-root=id:smart txn-num=@ud]
+  [town-id=id:smart batch-root=id:smart txn-num=@ud]
 ::
 +$  location-index
   (map @ux (jar @ux location))
@@ -40,8 +40,8 @@
 +$  second-order-index
   (map @ux (jar @ux second-order-location))
 ::
-+$  batches-by-shard
-  (map shard-id=id:smart batches-and-order)
++$  batches-by-town
+  (map town-id=id:smart batches-and-order)
 +$  batches-and-order
   [=batches =batch-order]
 +$  batches
@@ -49,15 +49,15 @@
 +$  batch-order
   (list id:smart)  ::  0-index -> most recent batch
 +$  batch
-  [transactions=(list [@ux transaction:smart]) shard:seq]
-+$  newest-batch-by-shard
-  %+  map  shard-id=id:smart
+  [transactions=(list [@ux transaction:smart]) town:seq]
++$  newest-batch-by-town
+  %+  map  town-id=id:smart
   [batch-id=id:smart timestamp=@da =batch]
 ::
-+$  shard-update-queue
-  (map shard-id=@ux (map batch-id=@ux timestamp=@da))
++$  town-update-queue
+  (map town-id=@ux (map batch-id=@ux timestamp=@da))
 +$  sequencer-update-queue
-  (map shard-id=@ux (map batch-id=@ux batch))
+  (map town-id=@ux (map batch-id=@ux batch))
 ::
 +$  versioned-state
   $%  base-state-0
@@ -65,10 +65,10 @@
 ::
 +$  base-state-0
   $:  %0
-      =batches-by-shard
+      =batches-by-town
       =capitol:seq
       =sequencer-update-queue
-      =shard-update-queue
+      =town-update-queue
       old-sub-paths=(map path @ux)
       old-sub-updates=(map @ux update)
       catchup-indexer=dock
@@ -82,13 +82,13 @@
       holder-index=second-order-index
       source-index=second-order-index
       to-index=second-order-index
-      =newest-batch-by-shard
+      =newest-batch-by-town
   ==
 ::
 +$  inflated-state-0  [base-state-0 indices-0]
 ::
 +$  batch-update-value
-  [timestamp=@da location=shard-location =batch]
+  [timestamp=@da location=town-location =batch]
 +$  txn-update-value
   [timestamp=@da location=txn-location =transaction:smart]
 +$  item-update-value
@@ -118,21 +118,21 @@
 :: +$  update
 ::   $@  ~
 ::   $%  [%path-does-not-exist ~]
-::       [%batches (map batch-id=id:smart [timestamp=@da location=shard-location =batch])]
+::       [%batches (map batch-id=id:smart [timestamp=@da location=town-location =batch])]
 ::       [%batch-order =batch-order]
 ::       [%txns (map txn-id=id:smart [timestamp=@da location=txn-location =transaction:smart])]
 ::       [%items (jar item-id=id:smart [timestamp=@da location=batch-location =item:smart])]
 ::       $:  %hashes
-::           batches=(map batch-id=id:smart [timestamp=@da location=shard-location =batch])
+::           batches=(map batch-id=id:smart [timestamp=@da location=town-location =batch])
 ::           txns=(map txn-id=id:smart [timestamp=@da location=txn-location =transaction:smart])
 ::           items=(jar item-id=id:smart [timestamp=@da location=batch-location =item:smart])
 ::       ==
-::       [%batch batch-id=id:smart timestamp=@da location=shard-location =batch]
+::       [%batch batch-id=id:smart timestamp=@da location=town-location =batch]
 ::       [%newest-batch-id batch-id=id:smart]  ::  keep?
 ::       [%txn txn-id=id:smart timestamp=@da location=txn-location =transaction:smart]
 ::       [%item item-id=id:smart timestamp=@da location=batch-location =item:smart]
 ::       $:  %hash
-::           batch=[batch-id=id:smart timestamp=@da location=shard-location =batch]
+::           batch=[batch-id=id:smart timestamp=@da location=town-location =batch]
 ::           txn=[txn-id=id:smart timestamp=@da location=txn-location =transaction:smart]
 ::           item=[item-id=id:smart timestamp=@da location=batch-location =item:smart]
 ::       ==

--- a/sur/zig/rollup.hoon
+++ b/sur/zig/rollup.hoon
@@ -7,8 +7,8 @@
 |%
 +$  action
   $%  [%activate ~]
-      [%launch-shard from=address:smart =sig:smart shard]
-      [%bridge-assets shard-id=id:smart assets=state]
+      [%launch-town from=address:smart =sig:smart town]
+      [%bridge-assets town-id=id:smart assets=state]
       [%receive-batch from=address:smart batch]
   ==
 --

--- a/sur/zig/sequencer.hoon
+++ b/sur/zig/sequencer.hoon
@@ -4,10 +4,10 @@
 +$  ship-sig   [p=@ux q=ship r=life]
 +$  sequencer  (pair address:smart ship)
 ::
-+$  shard  [=chain =hall]
++$  town  [=chain =hall]
 ::
 +$  hall
-  $:  shard-id=@ux
+  $:  town-id=@ux
       batch-num=@ud
       =sequencer
       mode=availability-method
@@ -15,21 +15,21 @@
       roots=(list @ux)
   ==
 ::
-::  capitol: tracks sequencer and state roots / diffs for all shards
+::  capitol: tracks sequencer and state roots / diffs for all towns
 ::
 +$  capitol  (map @ux hall)
 ::
-::  shard state transition
+::  town state transition
 ::
 +$  batch
-  $:  shard-id=id:smart
+  $:  town-id=id:smart
       num=@ud
       mode=availability-method
       state-diffs=(list state)
       diff-hash=@ux
       new-root=@ux
       new-state=chain
-      peer-roots=(map id:smart @ux)  ::  roots for all other shards
+      peer-roots=(map id:smart @ux)  ::  roots for all other towns
       =sig:smart                     ::  sequencer signs new state root
   ==
 ::
@@ -38,13 +38,13 @@
       [%committee members=(map address:smart [ship (unit sig:smart)])]
   ==
 ::
-+$  shard-action
++$  town-action
   $%  ::  administration
       $:  %init
           rollup-host=ship
           =address:smart
           private-key=@ux
-          shard-id=@ux
+          town-id=@ux
           starting-state=(unit chain)
           mode=availability-method
       ==
@@ -59,16 +59,16 @@
 ::
 +$  rollup-update
   $%  capitol-update
-      shard-update
+      town-update
   ==
 +$  capitol-update  [%new-capitol =capitol]
-+$  shard-update
-  $%  [%new-peer-root shard=id:smart root=@ux timestamp=@da]
-      [%new-sequencer shard=id:smart who=ship]
++$  town-update
+  $%  [%new-peer-root town=id:smart root=@ux timestamp=@da]
+      [%new-sequencer town=id:smart who=ship]
   ==
 ::
 ::  indexer must verify root is posted to rollup before verifying new state
-::  pair of [transactions shard] is batch from sur/indexer.hoon
+::  pair of [transactions town] is batch from sur/indexer.hoon
 +$  indexer-update
-  [%update root=@ux transactions=(list [@ux transaction:smart]) shard]
+  [%update root=@ux transactions=(list [@ux transaction:smart]) town]
 --

--- a/sur/zig/uqbar.hoon
+++ b/sur/zig/uqbar.hoon
@@ -4,9 +4,9 @@
 ::  pokes
 ::
 +$  action
-  $%  [%set-sources shards=(list [shard=id:smart (set dock)])]
-      [%add-source shard=id:smart source=dock]
-      [%remove-source shard=id:smart source=dock]
+  $%  [%set-sources towns=(list [town=id:smart (set dock)])]
+      [%add-source town=id:smart source=dock]
+      [%remove-source town=id:smart source=dock]
       [%set-wallet-source app-name=@tas]  ::  to plug in a third-party wallet app
       [%ping ~]
   ==

--- a/sur/zig/wallet.hoon
+++ b/sur/zig/wallet.hoon
@@ -7,15 +7,15 @@
 ::
 +$  book  (map id:smart asset)
 +$  asset
-  $%  [%token shard=@ux contract=id:smart metadata=id:smart token-account]
-      [%nft shard=@ux contract=id:smart metadata=id:smart nft]
-      [%unknown shard=@ux contract=id:smart *]
+  $%  [%token town=@ux contract=id:smart metadata=id:smart token-account]
+      [%nft town=@ux contract=id:smart metadata=id:smart nft]
+      [%unknown town=@ux contract=id:smart *]
   ==
 ::
 +$  metadata-store  (map id:smart asset-metadata)
 +$  asset-metadata
-  $%  [%token shard=@ux token-metadata]
-      [%nft shard=@ux nft-metadata]
+  $%  [%token town=@ux token-metadata]
+      [%nft town=@ux nft-metadata]
   ==
 ::
 +$  transaction-store
@@ -67,7 +67,7 @@
       [%sign-typed-message from=address:smart =typed-message:smart]
       [%add-tracked-address address=@ux nick=@t]
       ::  testing and internal
-      [%set-nonce address=@ux shard=@ux new=@ud]
+      [%set-nonce address=@ux town=@ux new=@ud]
       ::
       ::  TX submit pokes
       ::
@@ -94,7 +94,7 @@
       $:  %transaction
           from=address:smart
           contract=id:smart
-          shard=@ux
+          town=@ux
           action=supported-actions
       ==
   ==

--- a/sur/zig/ziggurat.hoon
+++ b/sur/zig/ziggurat.hoon
@@ -59,11 +59,11 @@
           [%compile-contracts ~]  ::  alterations to project files call %compile-contracts which calls %read-desk which sends a project update; TODO: skip compile when no change?
           [%read-desk ~]
           ::
-          [%add-to-state salt=@ label=@tas noun=* source=id:smart holder=id:smart shard-id=@ux]
+          [%add-to-state salt=@ label=@tas noun=* source=id:smart holder=id:smart town-id=@ux]
           [%delete-from-state =id:smart]
           ::
           [%add-test name=(unit @t) for-contract=id:smart action=@t expected-error=(unit @ud)]  ::  name optional
-          [%add-test-expectation test-id=@ux salt=@ label=@tas noun=* source=id:smart holder=id:smart shard-id=@ux]
+          [%add-test-expectation test-id=@ux salt=@ label=@tas noun=* source=id:smart holder=id:smart town-id=@ux]
           [%delete-test-expectation id=@ux delete=id:smart]
           [%delete-test id=@ux]
           [%edit-test id=@ux name=(unit @t) for-contract=id:smart action=@t expected-error=(unit @ud)]
@@ -76,7 +76,7 @@
               =address:smart
               rate=@ud  bud=@ud
               =deploy-location
-              shard-id=@ux
+              town-id=@ux
               upgradable=?
           ==
       ==

--- a/ted/indexer-bootstrap.hoon
+++ b/ted/indexer-bootstrap.hoon
@@ -19,7 +19,7 @@
 =/  m  (strand ,vase)
 ^-  form:m
 =/  arg-mold
-  $:  shard-id=@ux
+  $:  town-id=@ux
       indexer-ship=ship
       sequencer-ship=ship
       rollup-ship=ship
@@ -27,10 +27,10 @@
 =/  args  !<((unit arg-mold) arg)
 ?~  args
   ~&  >>>  "Usage:"
-  ~&  >>>  "-zig!indexer-bootstrap shard-id indexer-ship sequencer-ship rollup-ship"
+  ~&  >>>  "-zig!indexer-bootstrap town-id indexer-ship sequencer-ship rollup-ship"
   (pure:m !>(~))
 ::
-=*  shard-id         shard-id.u.args
+=*  town-id         town-id.u.args
 =*  indexer-ship    indexer-ship.u.args
 =*  sequencer-ship  sequencer-ship.u.args
 =*  rollup-ship     rollup-ship.u.args
@@ -47,7 +47,7 @@
 ::
 ;<  batch-order=(list @ux)  bind:m
   %+  scry  (list @ux)
-  /gx/indexer/batch-order/(scot %ux shard-id)/noun
+  /gx/indexer/batch-order/(scot %ux town-id)/noun
 ~&  >  "indexer now has batch-order: {<batch-order>}"
 ~&  >  "subscribing to %sequencer at {<sequencer-ship>}..."
 ;<  ~  bind:m
@@ -60,6 +60,6 @@
 ~&  >  "setting %uqbar source to our %indexer..."
 ;<  ~  bind:m
   %^  poke-our  %uqbar  %uqbar-action
-  !>(`action:uqbar`[%set-sources [shard-id [indexer-ship]~]~])
+  !>(`action:uqbar`[%set-sources [town-id [indexer-ship]~]~])
 ~&  >  "done"
 (pure:m !>(~))

--- a/ted/open-faucet.hoon
+++ b/ted/open-faucet.hoon
@@ -12,19 +12,19 @@
 ^-  form:m
 =/  arg-mold
   $:  faucet-host=@p
-      shard-id=id:smart
+      town-id=id:smart
       =address:smart
   ==
 =/  args  !<((unit arg-mold) arg)
 ?~  args
   ~&  >  "open-faucet: Poke the %faucet app on faucet-host"
   ~&  >  "             to receive some native tokens to address"
-  ~&  >  "Usage: -zig!open-faucet faucet-host shard-id address"
+  ~&  >  "Usage: -zig!open-faucet faucet-host town-id address"
 =*  faucet-host  faucet-host.u.args
-=*  shard-id      shard-id.u.args
+=*  town-id      town-id.u.args
 =*  address      address.u.args
 ::
 ;<  ~  bind:m
   %^  poke  [faucet-host %faucet]  %faucet-action
-  !>(`action:f`[%open shard-id address])
+  !>(`action:f`[%open town-id address])
 (pure:m !>(~))

--- a/tests/contracts/fungible.hoon
+++ b/tests/contracts/fungible.hoon
@@ -12,7 +12,7 @@
 ++  big  (bi:merk id:smart item:smart)  ::  merkle engine for granary
 ++  pig  (bi:merk id:smart @ud)          ::                for populace
 ++  batch-num  1
-++  shard-id    0x2
+++  town-id    0x2
 ++  rate    1
 ++  budget  100.000
 ++  fake-sig   [0 0 0]
@@ -50,7 +50,7 @@
   ++  holder-4  0xface.face.face.face.face.face.face.face.face.face
   ++  zig-id
     |=  holder=id:smart
-    (fry-data:smart zigs-contract-id:smart holder shard-id `@`'zigs')
+    (fry-data:smart zigs-contract-id:smart holder town-id `@`'zigs')
   ++  zig-account
     |=  [holder=id:smart amt=@ud]
     ^-  item:smart
@@ -60,7 +60,7 @@
         id
         zigs-contract-id:smart
         holder
-        shard-id
+        town-id
     ==
   ++  wheat
     ^-  item:smart
@@ -74,7 +74,7 @@
         zigs-contract-id:smart  ::  id
         zigs-contract-id:smart  ::  lord
         zigs-contract-id:smart  ::  holder
-        shard-id
+        town-id
     ==
   --
 ::
@@ -86,13 +86,13 @@
   ::  meta - metadata of the fungible account. defaults to `@ux`'simple' unless provided
   ^-  item:smart
   ?>  ?=(%& -.meta)
-  =/  id  (fry-data:smart id.p:fungible-wheat holder shard-id salt.p.meta)
+  =/  id  (fry-data:smart id.p:fungible-wheat holder town-id salt.p.meta)
   :*  %&  salt.p.meta  %account
       [amt allowances id.p:meta 0]
       id
       id.p:fungible-wheat
       holder
-      shard-id
+      town-id
   ==
 ::
 ++  account-1-mintable
@@ -125,7 +125,7 @@
       id=`@ux`'fungible'
       lord=`@ux`'fungible'
       holder=`@ux`'fungible'
-      shard-id
+      town-id
   ==
 ::
 ++  token-simple
@@ -146,7 +146,7 @@
       `@ux`'simple-metadata-1'
       id.p:fungible-wheat
       id.p:fungible-wheat
-      shard-id
+      town-id
   ==
 ++  token-mintable
   ^-  item:smart
@@ -166,7 +166,7 @@
       `@ux`'simple-mintable'
       id.p:fungible-wheat
       id.p:fungible-wheat
-      shard-id
+      town-id
   ==
 ++  token-different
   ^-  item:smart
@@ -186,7 +186,7 @@
       `@ux`'different-token'
       id.p:fungible-wheat
       id.p:fungible-wheat
-      shard-id
+      town-id
   ==
 ++  salt-of
   |=  tok=item:smart
@@ -241,11 +241,11 @@
   ^-  tang
   =/  action  [%set-allowance id:caller-3 10 id.p:account-1]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:fungible-wheat rate budget shard-id 0]
+    [caller-1 ~ id.p:fungible-wheat rate budget town-id 0]
   =/  updated-1=item:smart
     (fun-account id:caller-1 50 token-simple (malt ~[[id:caller-3 10]]))
   =/  milled=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
     fake-land  `transaction:smart`[fake-sig shel action]
   =/  res=item:smart  (got:big p.land.milled id.p:account-1)
   =*  correct  updated-1
@@ -257,11 +257,11 @@
   ^-  tang
   =/  action  [%give id:caller-2 30 id.p:account-1 `id.p:account-2]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:fungible-wheat rate budget shard-id 0]
+    [caller-1 ~ id.p:fungible-wheat rate budget town-id 0]
   =/  updated-1=item:smart  (fun-account id:caller-1 20 token-simple ~)
   =/  updated-2=item:smart  (fun-account id:caller-2 80 token-simple ~)
   =/  milled=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
     fake-land  `transaction:smart`[fake-sig shel action]
   =/  expected=granary  (gas:big *granary ~[[id.p:updated-1 updated-1] [id.p:updated-2 updated-2]])
   ::  N.B. we use int to filter out any grains whose keys are not in expected,
@@ -272,11 +272,11 @@
   ^-  tang
   =/  action  [%give id:caller-4 30 id.p:account-1 ~]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:fungible-wheat rate budget shard-id 0]
-  =/  new-id  (fry-data:smart id.p:fungible-wheat id:caller-4 shard-id (salt-of token-simple))
+    [caller-1 ~ id.p:fungible-wheat rate budget town-id 0]
+  =/  new-id  (fry-data:smart id.p:fungible-wheat id:caller-4 town-id (salt-of token-simple))
   =/  new=item:smart  (fun-account id:caller-4 30 token-simple ~)
   =/  milled=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
     fake-land  `transaction:smart`[fake-sig shel action]
   =/  res=item:smart  (got:big p.land.milled new-id)
   =*  correct  new
@@ -286,18 +286,18 @@
   ::  should fail on a subtract
   =/  action  [%give id:caller-2 51 id.p:account-1 `id.p:account-2]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:fungible-wheat rate budget shard-id 0]
+    [caller-1 ~ id.p:fungible-wheat rate budget town-id 0]
   =/  milled=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
     fake-land  `transaction:smart`[fake-sig shel action]
   (expect-eq !>(%6) !>(errorcode.milled))
 ++  test-give-metadata-mismatch
   ^-  tang
   =/  action  [%give id:caller-4 10 id.p:account-1 `id.p:account-4-different]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:fungible-wheat rate budget shard-id 0]
+    [caller-1 ~ id.p:fungible-wheat rate budget town-id 0]
   =/  milled=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
     fake-land  `transaction:smart`[fake-sig shel action]
   (expect-eq !>(%6) !>(errorcode.milled))
 ::
@@ -309,11 +309,11 @@
   ::  will produce a new account for caller-4, who has none
   =/  action  [%take id:caller-4 10 id.p:account-3 ~]
   =/  shel=shell:smart
-    [caller-4 ~ id.p:fungible-wheat rate budget shard-id 0]
-  =/  new-id=id:smart  (fry-data:smart id.p:fungible-wheat id:caller-4 shard-id (salt-of token-simple))
+    [caller-4 ~ id.p:fungible-wheat rate budget town-id 0]
+  =/  new-id=id:smart  (fry-data:smart id.p:fungible-wheat id:caller-4 town-id (salt-of token-simple))
   =/  correct=item:smart  (fun-account id:caller-4 10 token-simple ~)
   =/  milled=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
     fake-land  `transaction:smart`[fake-sig shel action]
   =/  res=item:smart  (got:big p.land.milled new-id)
   (expect-eq !>(correct) !>(res))
@@ -328,7 +328,7 @@
         ~[[id:caller-1 `id.p:account-1-mintable 50] [id:caller-2 `id.p:account-2-mintable 10]]
     ==
   =/  shel=shell:smart
-    [caller-1 ~ id.p:fungible-wheat rate budget shard-id 0]
+    [caller-1 ~ id.p:fungible-wheat rate budget town-id 0]
   =/  new-simp-meta=item:smart
     =-  [%& tok(supply.data 160)]
     tok=(husk:smart token-metadata-mold token-mintable ~ ~)
@@ -337,7 +337,7 @@
   =/  updated-2=item:smart
     (fun-account id:caller-2 60 token-mintable ~)
   =/  milled=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
     fake-land  `transaction:smart`[fake-sig shel action]
   =/  expected=granary  (gilt ~[new-simp-meta updated-1 updated-2])
   =/  res=granary       (int:big expected p.land.milled)
@@ -347,11 +347,11 @@
   =/  action
     [%mint id.p:token-mintable ~[[id:caller-3 ~ 50]]]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:fungible-wheat rate budget shard-id 0]
+    [caller-1 ~ id.p:fungible-wheat rate budget town-id 0]
   =/  expected=item:smart
     (fun-account id:caller-3 50 token-mintable ~)
   =/  milled=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
     fake-land  `transaction:smart`[fake-sig shel action]
   =/  res=item:smart  (got:big p.land.milled id.p:expected)
   (expect-eq !>(expected) !>(res))
@@ -368,7 +368,7 @@
 ::  =/  nonce         0
 ::  =/  deadline      (add batch-num 1)
 ::  =/  =typed-message:smart
-::    :-  (fry-data:smart id.p:fungible-wheat id:caller-1 shard-id (salt-of account-1))
+::    :-  (fry-data:smart id.p:fungible-wheat id:caller-1 town-id (salt-of account-1))
 ::    (sham [id:caller-1 to amount nonce deadline])
 ::  =/  sig
 ::    %+  ecdsa-raw-sign:secp256k1:secp:crypto
@@ -378,14 +378,14 @@
 ::    [%take-with-sig to `account from-account amount nonce deadline sig]
 ::  ::  this bad boi guzzles gas like crazy
 ::  =/  shel=shell:smart
-::    [caller-2 ~ id.p:fungible-wheat rate 999.999.999 shard-id 0]
+::    [caller-2 ~ id.p:fungible-wheat rate 999.999.999 town-id 0]
 ::  =/  updated-1=item:smart
 ::    =-  [%& g(nonce.data 1)]
 ::    g=(husk:smart account:sur:fun (fun-account id:caller-1 20 token-simple ~) ~ ~)
 ::  =/  updated-2=item:smart
 ::    (fun-account id:caller-2 60 token-simple ~)
 ::  =/  milled=single-result
-::    %+  ~(mill mil miller shard-id 1)
+::    %+  ~(mill mil miller town-id 1)
 ::    fake-land  `transaction:smart`[fake-sig shel action]
 ::  =/  expected=granary  (gilt ~[updated-1 updated-2])
 ::  =/  res=granary       (int:big expected p.land.milled)
@@ -398,7 +398,7 @@
 ::  =/  amount  30
 ::  =/  nonce  0
 ::  =/  deadline  (add batch-num 1)
-::  =/  =typed-message  :-  (fry-data:smart id.p:fungible-wheat id:caller-1 shard-id `@`'salt')
+::  =/  =typed-message  :-  (fry-data:smart id.p:fungible-wheat id:caller-1 town-id `@`'salt')
 ::                      (sham [id:caller-1 to amount nonce deadline])
 ::  =/  sig  %+  ecdsa-raw-sign:secp256k1:secp:crypto
 ::             (sham typed-message)
@@ -406,14 +406,14 @@
 ::  =/  =action:sur
 ::    [%take-with-sig to account from-account amount nonce deadline sig]
 ::  =/  =cart
-::    [id.p:fungible-wheat [id:caller-2 0] batch-num shard-id] :: cart no longer knows account-2' rice
+::    [id.p:fungible-wheat [id:caller-2 0] batch-num town-id] :: cart no longer knows account-2' rice
 ::  =/  updated-1=item:smart
 ::    :*  %&  `@`'salt'  %account
 ::        `account:sur`[20 ~ `@ux`'simple' 1]
 ::        0x1.beef
 ::        id.p:fungible-wheat
 ::        id:caller-1
-::        shard-id
+::        town-id
 ::    ==
 ::  =/  new-id  (fry-data:smart id:caller-2 id.p:fungible-wheat 0x1 `@`'salt')
 ::  =/  new=item:smart
@@ -422,7 +422,7 @@
 ::        new-id
 ::        id.p:fungible-wheat
 ::        id:caller-2
-::        shard-id
+::        town-id
 ::    ==
 ::  =/  res=chick:smart
 ::    (~(write cont cart) action)
@@ -430,7 +430,7 @@
 ::    [%take-with-sig id:caller-2 `new-id 0x1.beef amount nonce deadline sig]
 ::  =/  correct=chick:smart
 ::    %+  continuation
-::      [me.cart shard-id.cart correct-act]~
+::      [me.cart town-id.cart correct-act]~
 ::    (result:smart ~ ~[new] ~ ~)
 ::  (expect-eq !>(res) !>(correct))
 ::::
@@ -453,19 +453,19 @@
 ::            (silt ~[id:caller-1])
 ::            id:caller-1
 ::        ==
-::        (fry-data:smart id.p:fungible-wheat id.p:fungible-wheat shard-id token-salt)
+::        (fry-data:smart id.p:fungible-wheat id.p:fungible-wheat town-id token-salt)
 ::        id.p:fungible-wheat
 ::        id.p:fungible-wheat
-::        shard-id
+::        town-id
 ::    ==
 ::  =/  new-account=item:smart
 ::    (fun-account id:caller-1 900 new-token-metadata ~)
 ::  =/  =action:sur:fun
 ::    [%deploy (silt ~[[id:caller-1 900]]) (silt ~[id:caller-1]) 'Test Coin' 'TC' 0 1.000 %.y]
 ::  =/  shel=shell:smart
-::    [caller-1 ~ id.p:fungible-wheat rate budget shard-id 0]
+::    [caller-1 ~ id.p:fungible-wheat rate budget town-id 0]
 ::  =/  milled=single-result
-::    %+  ~(mill mil miller shard-id 1)
+::    %+  ~(mill mil miller town-id 1)
 ::    fake-land  `transaction:smart`[fake-sig shel action]
 ::  =/  expected=granary  (gilt ~[new-account new-token-metadata])
 ::  =/  res=granary       (int:big expected p.land.milled)

--- a/tests/contracts/multisig.hoon
+++ b/tests/contracts/multisig.hoon
@@ -13,7 +13,7 @@
 ::
 ++  big  (bi:merk id:smart item:smart)  ::  merkle engine for granary
 ++  pig  (bi:merk id:smart @ud)          ::                for populace
-++  shard-id   0x0
+++  town-id   0x0
 ++  batch-num  1
 ++  fake-sig  [0 0 0]
 ++  mil
@@ -50,11 +50,11 @@
         zigs-contract-id:smart  ::  id
         zigs-contract-id:smart  ::  lord
         zigs-contract-id:smart  ::  holder
-        shard-id
+        town-id
     ==
   ++  make-id
     |=  holder=id:smart
-    (fry-data:smart zigs-contract-id:smart holder shard-id `@`'zigs')
+    (fry-data:smart zigs-contract-id:smart holder town-id `@`'zigs')
   ++  make-account
     |=  [holder=id:smart amt=@ud]
     ^-  item:smart
@@ -63,7 +63,7 @@
         (make-id holder)
         zigs-contract-id:smart
         holder
-        shard-id
+        town-id
     ==
   --
 ::
@@ -81,21 +81,21 @@
         0xdada.dada  ::  id
         0xdada.dada  ::  lord
         0xdada.dada  ::  holder
-        shard-id
+        town-id
     ==
   ++  id
-    (fry-data:smart id.p:wheat:multisig id.p:wheat:multisig shard-id 0)
+    (fry-data:smart id.p:wheat:multisig id.p:wheat:multisig town-id 0)
   ++  proposal-1
-    :^  [id.p:wheat:multisig shard-id [%add-member id holder-3]]^~
+    :^  [id.p:wheat:multisig town-id [%add-member id holder-3]]^~
     ~  0  0
   ++  proposal-2
-    :^  [id.p:wheat:multisig shard-id [%remove-member id holder-3]]^~
+    :^  [id.p:wheat:multisig town-id [%remove-member id holder-3]]^~
     ~  0  0
   ++  proposal-3
-    :^  [id.p:wheat:multisig shard-id [%set-threshold id 2]]^~
+    :^  [id.p:wheat:multisig town-id [%set-threshold id 2]]^~
     ~  0  0
   ++  proposal-4
-    :^  [id.p:wheat:zigs shard-id [%give 0xdead.beef 123.456 (make-id:zigs 0xdada.dada) ~]]^~
+    :^  [id.p:wheat:zigs town-id [%give 0xdead.beef 123.456 (make-id:zigs 0xdada.dada) ~]]^~
     ~  0  0
   ++  grain
     ^-  item:smart
@@ -114,7 +114,7 @@
         id
         id.p:wheat:multisig
         id.p:wheat:multisig
-        shard-id
+        town-id
     ==
   --
 ::
@@ -143,7 +143,7 @@
 ::  types
 ::
 +$  proposal
-  $:  calls=(list [to=id:smart shard=id:smart =calldata:smart])
+  $:  calls=(list [to=id:smart town=id:smart =calldata:smart])
       votes=(pmap:smart address:smart ?)
       ayes=@ud
       nays=@ud
@@ -163,9 +163,9 @@
   =/  member-set  (~(gas pn:smart *(pset:smart address:smart)) ~[id:caller-1])
   =/  =calldata:smart  [%create 1 member-set]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id batch-num)
+    %+  ~(mill mil miller town-id batch-num)
       fake-land
     `transaction:smart`[fake-sig shel yolk]
   ::
@@ -175,9 +175,9 @@
 ++  test-create-no-members
   =/  =calldata:smart  [%create 0 ~]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id batch-num)
+    %+  ~(mill mil miller town-id batch-num)
       [(del:big fake-granary id:multisig) fake-populace]
     `transaction:smart`[fake-sig shel yolk]
   ::
@@ -188,9 +188,9 @@
   =/  member-set  (~(gas pn:smart *(pset:smart address:smart)) ~[id:caller-1])
   =/  =calldata:smart  [%create 2 ~]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id batch-num)
+    %+  ~(mill mil miller town-id batch-num)
       [(del:big fake-granary id:multisig) fake-populace]
     `transaction:smart`[fake-sig shel yolk]
   ::
@@ -203,14 +203,14 @@
     ~[id:caller-1 id:caller-2 id:caller-3 0xdead 0xbeef 0xcafe 0xbabe]
   =/  =calldata:smart  [%create 4 member-set]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id batch-num)
+    %+  ~(mill mil miller town-id batch-num)
       [(del:big fake-granary id:multisig) fake-populace]
     `transaction:smart`[fake-sig shel yolk]
   ::
   =/  correct-id
-    (fry-data:smart id.p:wheat:multisig id.p:wheat:multisig shard-id 0)
+    (fry-data:smart id.p:wheat:multisig id.p:wheat:multisig town-id 0)
   =/  correct
     ^-  item:smart
     :*  %&  0  %multisig
@@ -218,7 +218,7 @@
         correct-id
         id.p:wheat:multisig
         id.p:wheat:multisig
-        shard-id
+        town-id
     ==
   ::
   ;:  weld
@@ -236,9 +236,9 @@
 ++  test-vote-not-member
   =/  =calldata:smart  [%vote id:multisig 0x1 %.y]
   =/  shel=shell:smart
-    [caller-3 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-3 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id batch-num)
+    %+  ~(mill mil miller town-id batch-num)
       fake-land
     `transaction:smart`[fake-sig shel yolk]
   ::
@@ -248,9 +248,9 @@
 ++  test-vote-no-proposal
   =/  =calldata:smart  [%vote id:multisig 0x6789 %.y]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id batch-num)
+    %+  ~(mill mil miller town-id batch-num)
       fake-land
     `transaction:smart`[fake-sig shel yolk]
   ::
@@ -260,13 +260,13 @@
 ++  test-vote-aye
   =/  =calldata:smart  [%vote id:multisig 0x1 %.y]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id batch-num)
+    %+  ~(mill mil miller town-id batch-num)
       fake-land
     `transaction:smart`[fake-sig shel yolk]
   =/  correct-proposal
-    :^  [id.p:wheat:multisig shard-id [%add-member id:multisig holder-3]]^~
+    :^  [id.p:wheat:multisig town-id [%add-member id:multisig holder-3]]^~
       %-  ~(gas py:smart *(pmap:smart address:smart ?))
       [holder-1 %.y]^~
     1  0
@@ -285,9 +285,9 @@
 ++  test-vote-nay
   =/  =calldata:smart  [%vote id:multisig 0x1 %.n]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id batch-num)
+    %+  ~(mill mil miller town-id batch-num)
       fake-land
     `transaction:smart`[fake-sig shel yolk]
   ::  proposal will be removed
@@ -305,16 +305,16 @@
 ++  test-vote-run
   =/  =calldata:smart  [%vote id:multisig 0x1 %.y]
   =/  shel-1=shell:smart
-    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  shel-2=shell:smart
-    [caller-2 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-2 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  =basket:mill
     %-  silt
     :~  [(shag:smart [shel-1 yolk]) [fake-sig shel-1 yolk]]
         [(shag:smart [shel-2 yolk]) [fake-sig shel-2 yolk]]
     ==
   =/  res=[state-transition:mill rejected=carton:mill]
-    %-  ~(mill-all mil miller shard-id batch-num)
+    %-  ~(mill-all mil miller town-id batch-num)
     [fake-land basket 256]
   ::
   =/  correct
@@ -330,7 +330,7 @@
         id:multisig
         id.p:wheat:multisig
         id.p:wheat:multisig
-        shard-id
+        town-id
     ==
   ::
   %+  expect-eq
@@ -341,15 +341,15 @@
 ::
 ++  test-propose
   =/  my-proposal
-    [id.p:wheat:multisig shard-id [%add-member id:multisig 0xdead.beef]]^~
+    [id.p:wheat:multisig town-id [%add-member id:multisig 0xdead.beef]]^~
   =/  proposal-hash
     (shag:smart my-proposal)
   =/  =calldata:smart
     [%propose id:multisig my-proposal]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id batch-num)
+    %+  ~(mill mil miller town-id batch-num)
       fake-land
     `transaction:smart`[fake-sig shel yolk]
   =/  correct-proposal
@@ -371,12 +371,12 @@
 ::
 ++  test-propose-not-member
   =/  my-proposal
-    [id.p:wheat:multisig shard-id [%add-member id:multisig 0xdead.beef]]^~
+    [id.p:wheat:multisig town-id [%add-member id:multisig 0xdead.beef]]^~
   =/  =calldata:smart  [%propose id:multisig my-proposal]
   =/  shel=shell:smart
-    [caller-3 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-3 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id batch-num)
+    %+  ~(mill mil miller town-id batch-num)
       fake-land
     `transaction:smart`[fake-sig shel yolk]
   ::
@@ -386,16 +386,16 @@
 ++  test-proposal-4
   =/  =calldata:smart  [%vote id:multisig 0x4 %.y]
   =/  shel-1=shell:smart
-    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  shel-2=shell:smart
-    [caller-2 ~ id.p:wheat:multisig 1 1.000.000 shard-id 0]
+    [caller-2 ~ id.p:wheat:multisig 1 1.000.000 town-id 0]
   =/  =basket:mill
     %-  silt
     :~  [(shag:smart [shel-1 yolk]) [fake-sig shel-1 yolk]]
         [(shag:smart [shel-2 yolk]) [fake-sig shel-2 yolk]]
     ==
   =/  res=[state-transition:mill rejected=carton:mill]
-    %-  ~(mill-all mil miller shard-id batch-num)
+    %-  ~(mill-all mil miller town-id batch-num)
     [fake-land basket 256]
   ::
   =/  correct
@@ -411,7 +411,7 @@
         id:multisig
         id.p:wheat:multisig
         id.p:wheat:multisig
-        shard-id
+        town-id
     ==
   ::
   %+  expect-eq

--- a/tests/contracts/nft.hoon
+++ b/tests/contracts/nft.hoon
@@ -12,7 +12,7 @@
 ::
 ++  big  (bi:merk id:smart item:smart)  ::  merkle engine for granary
 ++  pig  (bi:merk id:smart @ud)          ::                for populace
-++  shard-id   0x0
+++  town-id   0x0
 ++  fake-sig  [0 0 0]
 ++  mil
   %~  mill  mill
@@ -38,10 +38,10 @@
         `@`'zigs'
         %account
         [300.000.000 ~ `@ux`'zigs-metadata']
-        (fry-data:smart zigs-contract-id:smart pubkey-1 shard-id `@`'zigs')
+        (fry-data:smart zigs-contract-id:smart pubkey-1 town-id `@`'zigs')
         zigs-contract-id:smart
         pubkey-1
-        shard-id
+        town-id
     ==
   --
 ::
@@ -62,9 +62,9 @@
       id=`@ux`'nft-metadata'
       lord=0xcafe.babe
       holder=0xcafe.babe
-      shard-id
+      town-id
   ==
-++  nft-1  (fry-data:smart 0xcafe.babe pubkey-1 shard-id `@`'nftsalt1')
+++  nft-1  (fry-data:smart 0xcafe.babe pubkey-1 town-id `@`'nftsalt1')
 ++  nft-rice
   ^-  data:smart
   :*  salt=`@`'nftsalt1'
@@ -80,7 +80,7 @@
       nft-1
       0xcafe.babe
       pubkey-1
-      shard-id
+      town-id
   ==
 ++  nft-wheat
   ^-  pact:smart
@@ -90,7 +90,7 @@
       0xcafe.babe  ::  id
       0xcafe.babe  ::  lord
       0xcafe.babe  ::  holder
-      shard-id      ::  shard-id
+      town-id      ::  town-id
   ==
 ::
 ++  fake-granary
@@ -114,9 +114,9 @@
 ++  test-mill-nft-give
   =/  =calldata:smart  [%give 0xffff.ffff.ffff.ffff id:nft-rice]
   =/  shel=shell:smart
-    [caller-1 ~ id:nft-wheat 1 1.000.000 shard-id 0]
+    [caller-1 ~ id:nft-wheat 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
       fake-land
     `transaction:smart`[fake-sig shel yolk]
   ::

--- a/tests/contracts/publish.hoon
+++ b/tests/contracts/publish.hoon
@@ -12,7 +12,7 @@
 ::
 ++  big  (bi:merk id:smart item:smart)  ::  merkle engine for granary
 ++  pig  (bi:merk id:smart @ud)          ::                for populace
-++  shard-id   0x0
+++  town-id   0x0
 ++  fake-sig  [0 0 0]
 ++  mil
   %~  mill  mill
@@ -36,7 +36,7 @@
   |%
   ++  make-id
     |=  holder=id:smart
-    (fry-data:smart zigs-contract-id:smart holder shard-id `@`'zigs')
+    (fry-data:smart zigs-contract-id:smart holder town-id `@`'zigs')
   ++  make-account
     |=  [holder=id:smart amt=@ud]
     ^-  item:smart
@@ -45,7 +45,7 @@
         (make-id holder)
         zigs-contract-id:smart
         holder
-        shard-id
+        town-id
     ==
   --
 ::
@@ -57,7 +57,7 @@
   [bat=[8 [1 0 [0 0] 0 0] [1 [8 [1 0] [1 [1 0] 1 0] 0 1] 8 [1 0] [1 8 [8 [9 2.398 0 16.127] 9 2 10 [6 7 [0 3] 1 100] 0 2] 1 0 0 0 0 0] 0 1] 0 1] pay=[1 0]]
 ::
 ++  upgradable-id
-  (fry-pact:smart id.p:publish-wheat id:caller-1 shard-id `trivial-nok)
+  (fry-pact:smart id.p:publish-wheat id:caller-1 town-id `trivial-nok)
 ++  upgradable
   ^-  item:smart
   :*  %|
@@ -67,11 +67,11 @@
         upgradable-id
         id.p:publish-wheat
         id:caller-1
-        shard-id
+        town-id
   ==
 ::
 ++  immutable-id
-  (fry-pact:smart 0x0 id:caller-1 shard-id `immutable-nok)
+  (fry-pact:smart 0x0 id:caller-1 town-id `immutable-nok)
 ++  immutable
   ^-  item:smart
   :*  %|
@@ -81,7 +81,7 @@
       immutable-id
       0x0
       id:caller-1
-      shard-id
+      town-id
   ==
 ::
 ++  publish-wheat
@@ -94,7 +94,7 @@
       0xdada.dada  ::  id
       0xdada.dada  ::  lord
       0xdada.dada  ::  holder
-      shard-id
+      town-id
   ==
 ::
 ++  fake-granary
@@ -121,9 +121,9 @@
 ++  test-deploy
   =/  =calldata:smart  [%deploy %.y trivial-nok ~ ~]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:publish-wheat 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:publish-wheat 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
       [(del:big fake-granary upgradable-id) fake-populace]
     `transaction:smart`[fake-sig shel yolk]
   ::
@@ -137,9 +137,9 @@
 ++  test-deploy-immutable
   =/  =calldata:smart  [%deploy %.n immutable-nok ~ ~]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:publish-wheat 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:publish-wheat 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
       [(del:big fake-granary immutable-id) fake-populace]
     `transaction:smart`[fake-sig shel yolk]
   ::
@@ -153,9 +153,9 @@
 ++  test-upgrade
   =/  =calldata:smart  [%upgrade upgradable-id trivial-nok-upgrade]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:publish-wheat 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:publish-wheat 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
       fake-land
     `transaction:smart`[fake-sig shel yolk]
   ::
@@ -168,7 +168,7 @@
         upgradable-id
         id.p:publish-wheat
         id:caller-1
-        shard-id
+        town-id
     ==
   ;:  weld
   ::  assert that our call went through
@@ -180,9 +180,9 @@
 ++  test-upgrade-immutable
   =/  =calldata:smart  [%upgrade immutable-id trivial-nok-upgrade]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:publish-wheat 1 1.000.000 shard-id 0]
+    [caller-1 ~ id.p:publish-wheat 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
       fake-land
     `transaction:smart`[fake-sig shel yolk]
   ::  assert that our call failed
@@ -191,9 +191,9 @@
 ++  test-upgrade-not-holder
   =/  =calldata:smart  [%upgrade immutable-id trivial-nok-upgrade]
   =/  shel=shell:smart
-    [caller-2 ~ id.p:publish-wheat 1 1.000.000 shard-id 0]
+    [caller-2 ~ id.p:publish-wheat 1 1.000.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id 1)
+    %+  ~(mill mil miller town-id 1)
       fake-land
     `transaction:smart`[fake-sig shel yolk]
   ::  assert that our call failed

--- a/tests/contracts/read.hoon
+++ b/tests/contracts/read.hoon
@@ -13,7 +13,7 @@
 ::
 ++  big  (bi:merk id:smart item:smart)  ::  merkle engine for state
 ++  pig  (bi:merk id:smart @ud)         ::                for nonces
-++  shard-id   0x0
+++  town-id   0x0
 ++  fake-sig  [0 0 0]
 ++  eng
   %~  engine  engine
@@ -33,10 +33,10 @@
   ++  account-1
     ^-  item:smart
     :*  %&
-        (hash-data:smart zigs-contract-id:smart pubkey-1 shard-id `@`'zigs')
+        (hash-data:smart zigs-contract-id:smart pubkey-1 town-id `@`'zigs')
         zigs-contract-id:smart
         pubkey-1
-        shard-id
+        town-id
         `@`'zigs'
         %account
         [300.000.000 ~ `@ux`'zigs-metadata']
@@ -48,7 +48,7 @@
   :*  0x5678  ::  id
       0x5678  ::  lord
       0x5678  ::  holder
-      shard-id
+      town-id
       [- +]:(cue trivial-read-contract)
       interface=~
       types=~
@@ -59,7 +59,7 @@
   :*  0x1234  ::  id
       0x1234  ::  lord
       0x1234  ::  holder
-      shard-id
+      town-id
       [- +]:(cue trivial-read-source-contract)
       interface=~
       types=~
@@ -81,9 +81,9 @@
 ++  test-read
   =/  =calldata:smart  [%read-me-for-free ~]
   =/  shel=shell:smart
-    [caller-1 ~ id:read-pact [1 1.000.000] shard-id %0]
+    [caller-1 ~ id:read-pact [1 1.000.000] town-id %0]
   =/  res=single-result:engine
-    %+  ~(run-single eng miller shard-id 1 0)
+    %+  ~(run-single eng miller town-id 1 0)
       fake-chain
     `transaction:smart`[fake-sig calldata shel]
   ::

--- a/tests/lib/mill-2.hoon
+++ b/tests/lib/mill-2.hoon
@@ -1,9 +1,9 @@
 ::
 ::  Tests for lib/zig/mill.hoon
-::  Basic goal: construct a simple shard / helix state
+::  Basic goal: construct a simple town / helix state
 ::  and manipulate it with some calls to our zigs contract.
 ::  Mill should handle clearing a mempool populated by
-::  calls and return an updated shard. The zigs contract
+::  calls and return an updated town. The zigs contract
 ::  should manage transactions properly so this is testing
 ::  the arms of that contract as well.
 ::
@@ -26,7 +26,7 @@
 ::
 ++  big  (bi:merk id:smart item:smart)  ::  merkle engine for granary
 ++  pig  (bi:merk id:smart @ud)         ::                for populace
-++  shard-id    0x0
+++  town-id    0x0
 ++  set-fee    7
 ++  fake-sig   [0 0 0]
 ++  eng
@@ -54,10 +54,10 @@
   ++  sequencer-account
     ^-  item:smart
     :*  %&
-        (hash-data:smart zigs-contract-id:smart 0x24c.23b9.8535.cd5a.0645.5486.69fb.afbf.095e.fcc0 shard-id `@`'zigs')
+        (hash-data:smart zigs-contract-id:smart 0x24c.23b9.8535.cd5a.0645.5486.69fb.afbf.095e.fcc0 town-id `@`'zigs')
         zigs-contract-id:smart
         0x24c.23b9.8535.cd5a.0645.5486.69fb.afbf.095e.fcc0
-        shard-id
+        town-id
         `@`'zigs'
         %account
         [1.000.000 ~ `@ux`'zigs-metadata' 0]
@@ -65,10 +65,10 @@
   ++  account-1
     ^-  item:smart
     :*  %&
-        (hash-data:smart zigs-contract-id:smart holder-1 shard-id `@`'zigs')
+        (hash-data:smart zigs-contract-id:smart holder-1 town-id `@`'zigs')
         zigs-contract-id:smart
         holder-1
-        shard-id
+        town-id
         `@`'zigs'
         %account
         [300.000.000 ~ `@ux`'zigs-metadata' 0]
@@ -76,10 +76,10 @@
   ++  account-2
     ^-  item:smart
     :*  %&
-        (hash-data:smart zigs-contract-id:smart holder-2 shard-id `@`'zigs')
+        (hash-data:smart zigs-contract-id:smart holder-2 town-id `@`'zigs')
         zigs-contract-id:smart
         holder-2
-        shard-id
+        town-id
         `@`'zigs'
         %account
         [200.000 ~ `@ux`'zigs-metadata' 0]
@@ -87,10 +87,10 @@
   ++  account-3
     ^-  item:smart
     :*  %&
-        (hash-data:smart zigs-contract-id:smart holder-3 shard-id `@`'zigs')
+        (hash-data:smart zigs-contract-id:smart holder-3 town-id `@`'zigs')
         zigs-contract-id:smart
         holder-3
-        shard-id
+        town-id
         `@`'zigs'
         %account
         [100.000 ~ `@ux`'zigs-metadata' 0]
@@ -102,7 +102,7 @@
         zigs-contract-id:smart  ::  id
         zigs-contract-id:smart  ::  source
         zigs-contract-id:smart  ::  holder
-        shard-id
+        town-id
         [-.code +.code]
         ~
         ~
@@ -118,7 +118,7 @@
 ::        0xdada.dada  ::  id
 ::        0xdada.dada  ::  source
 ::        0xdada.dada  ::  holder
-::        shard-id
+::        town-id
 ::        code
 ::        interface
 ::        types
@@ -136,7 +136,7 @@
 ::        0xcafe.cafe  ::  id
 ::        0xcafe.cafe  ::  source
 ::        0xcafe.cafe  ::  holder
-::        shard-id
+::        town-id
 ::    ==
 ::  ++  temp-grain
 ::    ^-  item:smart
@@ -147,7 +147,7 @@
 ::        0x1111.2222.3333
 ::        0xcafe.cafe
 ::        `@ux`123.456.789
-::        shard-id
+::        town-id
 ::    ==
 ::
 ++  fake-state
@@ -170,9 +170,9 @@
 ++  test-engine-zigs-give
   =/  =calldata:smart  [%give holder-2:zigs 1.000 id.p:account-1:zigs `id.p:account-2:zigs]
   =/  shel=shell:smart
-    [caller-1 ~ id.p:pact:zigs [1 1.000.000] shard-id 0]
+    [caller-1 ~ id.p:pact:zigs [1 1.000.000] town-id 0]
   =/  res=single-result:seq
-    %+  ~(run-single eng sequencer shard-id batch=1 eth-block-height=0)
+    %+  ~(run-single eng sequencer town-id batch=1 eth-block-height=0)
     fake-chain  [fake-sig calldata shel]
   ~&  >  "output: {<events.res>}"
   ~&  >  "fee: {<fee.res>}"
@@ -186,9 +186,9 @@
 ::  ++  test-mill-trivial-scry
 ::    =/  =calldata:smart  [%find id.p:account-1:zigs]
 ::    =/  shel=shell:smart
-::      [caller-1 ~ id.p:scry-pact 1 1.000.000 shard-id 0]
+::      [caller-1 ~ id.p:scry-pact 1 1.000.000 town-id 0]
 ::    =/  res=[fee=@ud =land burned=granary =errorcode:smart hits=(list) =crow:smart]
-::      %+  ~(mill mil sequencer shard-id 1)
+::      %+  ~(mill mil sequencer town-id 1)
 ::      fake-land  `transaction:smart`[fake-sig shel yolk]
 ::    ~&  >  "output: {<crow.res>}"
 ::    ~&  >  "fee: {<fee.res>}"
@@ -198,12 +198,12 @@
 ::    !>(errorcode.res)
 ::  ::
 ::  ++  test-mill-simple-burn
-::    ::               id of grain to burn, destination shard id
+::    ::               id of grain to burn, destination town id
 ::    =/  =calldata:smart  [%burn id.p:account-1:zigs 0x2]
 ::    =/  shel=shell:smart
-::      [caller-1 ~ 0x0 1 1.000.000 shard-id 0]
+::      [caller-1 ~ 0x0 1 1.000.000 town-id 0]
 ::    =/  res=[fee=@ud =land burned=granary =errorcode:smart hits=(list) =crow:smart]
-::      %+  ~(mill mil sequencer shard-id 1)
+::      %+  ~(mill mil sequencer town-id 1)
 ::      fake-land  `transaction:smart`[fake-sig shel yolk]
 ::    ~&  >  "output: {<crow.res>}"
 ::    ~&  >  "fee: {<fee.res>}"

--- a/tests/lib/mill.hoon
+++ b/tests/lib/mill.hoon
@@ -1,9 +1,9 @@
 ::
 ::  Tests for lib/zig/mill.hoon
-::  Basic goal: construct a simple shard / helix state
+::  Basic goal: construct a simple town / helix state
 ::  and manipulate it with some calls to our zigs contract.
 ::  Mill should handle clearing a mempool populated by
-::  calls and return an updated shard. The zigs contract
+::  calls and return an updated town. The zigs contract
 ::  should manage transactions properly so this is testing
 ::  the arms of that contract as well.
 ::
@@ -28,7 +28,7 @@
 ::  constants / dummy info for mill
 ::
 ++  init-now  *@da
-++  shard-id    0x0
+++  town-id    0x0
 ++  set-fee    7
 ++  fake-sig   [0 0 0]
 ++  mil
@@ -57,7 +57,7 @@
     :*  0x1.1512.3341
         zigs-contract-id
         0x1512.3341
-        shard-id
+        town-id
         [%& `@`'zigs' %account [1.000.000 ~ `@ux`'zigs-metadata']]
     ==
   ++  beef-account
@@ -65,7 +65,7 @@
     :*  0x1.beef
         zigs-contract-id
         holder-1
-        shard-id
+        town-id
         [%& `@`'zigs' %account [300.000 ~ `@ux`'zigs-metadata']]
     ==
   ++  dead-account
@@ -73,7 +73,7 @@
     :*  0x1.dead
         zigs-contract-id
         0xdead
-        shard-id
+        town-id
         [%& `@`'zigs' %account [200.000 ~ `@ux`'zigs-metadata']]
     ==
   ++  cafe-account
@@ -81,7 +81,7 @@
     :*  0x1.cafe
         zigs-contract-id
         0xcafe
-        shard-id
+        town-id
         [%& `@`'zigs' %account [100.000 ~ `@ux`'zigs-metadata']]
     ==
   ++  wheat-grain
@@ -90,7 +90,7 @@
     :*  zigs-contract-id
         zigs-contract-id
         zigs-contract-id
-        shard-id
+        town-id
         [%| wheat(owns (silt ~[0x1.beef 0x1.dead 0x1.cafe]))]
     ==
   --
@@ -101,7 +101,7 @@
   :*  0xdada.dada  ::  id
       0xdada.dada  ::  lord
       0xdada.dada  ::  holder
-      shard-id
+      town-id
       [%| wheat]
   ==
 ::
@@ -110,7 +110,7 @@
   :*  0xffff.ffff  ::  id
       0xffff.ffff  ::  lord
       0xffff.ffff  ::  holder
-      shard-id
+      town-id
       [%| ~ ~]
   ==
 ::
@@ -120,7 +120,7 @@
   :*  0xeeee.eeee  ::  id
       0xeeee.eeee  ::  lord
       0xeeee.eeee  ::  holder
-      shard-id
+      town-id
       [%| wheat(owns (silt ~[0x9999]))]
   ==
 ::
@@ -129,7 +129,7 @@
   :*  0x9999
       0xeeee.eeee
       holder-1:zigs
-      shard-id
+      town-id
       [%& `@`'some-salt' %some-label ['some' 'random' 'data']]
   ==
 ::
@@ -164,9 +164,9 @@
   =/  yok=yolk
     [`[%random-command ~] ~ ~]
   =/  shel=shell
-    [0xbeef fake-sig ~ id:triv-wheat 1 333 shard-id 0]
+    [0xbeef fake-sig ~ id:triv-wheat 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -191,9 +191,9 @@
   =/  yok=yolk
     [`[%random-command ~] ~ ~]
   =/  shel=shell
-    [[0xbeef 2 0x1.beef] fake-sig ~ id:triv-wheat 1 333 shard-id 0]
+    [[0xbeef 2 0x1.beef] fake-sig ~ id:triv-wheat 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -218,9 +218,9 @@
   =/  yok=yolk
     [`[%random-command ~] ~ ~]
   =/  shel=shell
-    [[0xbeef 0 0x1.beef] fake-sig ~ id:triv-wheat 1 333 shard-id 0]
+    [[0xbeef 0 0x1.beef] fake-sig ~ id:triv-wheat 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -245,9 +245,9 @@
   =/  yok=yolk
     [`[%random-command ~] ~ ~]
   =/  shel=shell
-    [[0xbeef 1 0x2.beef] fake-sig ~ id:triv-wheat 1 333 shard-id 0]
+    [[0xbeef 1 0x2.beef] fake-sig ~ id:triv-wheat 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -272,9 +272,9 @@
   =/  yok=yolk
     [`[%random-command ~] ~ ~]
   =/  shel=shell
-    [[0xbeef 1 0x1.dead] fake-sig ~ id:triv-wheat 1 333 shard-id 0]
+    [[0xbeef 1 0x1.dead] fake-sig ~ id:triv-wheat 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -300,9 +300,9 @@
     [`[%random-command ~] ~ ~]
   =/  hash=@ux  `@ux`(sham yok)
   =/  shel=shell
-    [caller-1 fake-sig ~ id:triv-wheat 1 300.001 shard-id 0]
+    [caller-1 fake-sig ~ id:triv-wheat 1 300.001 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -328,9 +328,9 @@
     [`[%random-command ~] ~ ~]
   =/  hash=@ux  `@ux`(sham yok)
   =/  shel=shell
-    [caller-1 fake-sig ~ 0x27.3708.9341 1 333 shard-id 0]
+    [caller-1 fake-sig ~ 0x27.3708.9341 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -356,9 +356,9 @@
     [`[%random-command ~] ~ ~]
   =/  hash=@ux  `@ux`(sham yok)
   =/  shel=shell
-    [caller-1 fake-sig ~ id:dead-account:zigs 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:dead-account:zigs 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -384,9 +384,9 @@
     [`[%random-command ~] ~ ~]
   =/  hash=@ux  `@ux`(sham yok)
   =/  shel=shell
-    [caller-1 fake-sig ~ id:empty-wheat 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:empty-wheat 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -413,9 +413,9 @@
       ~
     (silt ~[id:dummy-grain id:beef-account:zigs])
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -446,9 +446,9 @@
       (silt ~[id:dummy-grain id:beef-account:zigs])
     ~
   =/  shel=shell
-    [caller-2 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-2 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -476,9 +476,9 @@
   =/  yok=yolk
     [`[%random-command ~] ~ ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:triv-wheat 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:triv-wheat 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -509,9 +509,9 @@
       (silt ~[id:beef-account:zigs])
     (silt ~[id:dead-account:zigs])
   =/  shel=shell
-    [caller-1 fake-sig ~ zigs-contract-id 1 333 shard-id 0]
+    [caller-1 fake-sig ~ zigs-contract-id 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -549,9 +549,9 @@
       (silt ~[id:beef-account:zigs])
     (silt ~[id:dead-account:zigs])
   =/  shel=shell
-    [caller-1 fake-sig ~ zigs-contract-id 1 100.000 shard-id 0]
+    [caller-1 fake-sig ~ zigs-contract-id 1 100.000 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -584,9 +584,9 @@
   =/  yok=yolk
     [`[%change-nonexistent ~] ~ ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -614,9 +614,9 @@
   =/  yok=yolk
     [`[%change-type ~] ~ ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -638,9 +638,9 @@
   =/  yok=yolk
     [`[%change-id ~] (silt ~[id:dummy-grain]) ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -662,9 +662,9 @@
   =/  yok=yolk
     [`[%change-salt ~] (silt ~[id:dummy-grain]) ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -686,9 +686,9 @@
   =/  yok=yolk
     [`[%change-lord ~] (silt ~[id:dummy-grain]) ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -713,9 +713,9 @@
   =/  yok=yolk
     [`[%changed-issued-overlap ~] ~ ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -739,9 +739,9 @@
       (silt ~[id:beef-account:zigs])
     ~
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -765,9 +765,9 @@
   =/  yok=yolk
     [`[%issue-non-matching-id ~] ~ ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -789,9 +789,9 @@
   =/  yok=yolk
     [`[%issue-bad-rice-id ~] ~ ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -813,9 +813,9 @@
   =/  yok=yolk
     [`[%issue-bad-wheat-id ~] ~ ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -837,9 +837,9 @@
   =/  yok=yolk
     [`[%issue-without-provenance ~] ~ ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -861,9 +861,9 @@
   =/  yok=yolk
     [`[%issue-already-existing ~] (silt ~[id:beef-account:zigs]) ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -888,9 +888,9 @@
   =/  yok=yolk
     [`[%burn-nonexistent ~] ~ ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -912,9 +912,9 @@
   =/  yok=yolk
     [`[%burn-non-matching-id ~] (silt ~[id:dummy-grain]) ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -936,9 +936,9 @@
   =/  yok=yolk
     [`[%burn-changed-overlap ~] (silt ~[id:dummy-grain]) ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -963,9 +963,9 @@
   =/  yok=yolk
     [`[%burn-issued-overlap ~] ~ ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -987,9 +987,9 @@
   =/  yok=yolk
     [`[%burn-without-provenance ~] (silt ~[id:beef-account:zigs]) ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -1011,9 +1011,9 @@
   =/  yok=yolk
     [`[%burn-change-lord ~] (silt ~[id:dummy-grain]) ~]
   =/  shel=shell
-    [caller-1 fake-sig ~ id:mill-tester 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:mill-tester 1 333 town-id 0]
   =/  res=single-result
-    %+  ~(mill mil miller shard-id init-now)
+    %+  ~(mill mil miller town-id init-now)
     fake-land  [shel yok]
   ::
   ;:  weld
@@ -1040,9 +1040,9 @@
     [`[%random-command ~] ~ ~]
   =/  hash=@ux  `@ux`(sham yok)
   =/  shel=shell
-    [caller-1 fake-sig ~ id:triv-wheat 1 300.001 shard-id 0]
+    [caller-1 fake-sig ~ id:triv-wheat 1 300.001 town-id 0]
   =/  [res=state-transition rej=carton]
-    %^  ~(mill-all mil miller shard-id init-now)
+    %^  ~(mill-all mil miller town-id init-now)
     fake-land  (silt ~[[hash [shel yok]]])  1.024
   ;:  weld
   ::  assert that our call failed with correct errorcode
@@ -1060,9 +1060,9 @@
     [`[%random-command ~] ~ ~]
   =/  hash=@ux  `@ux`(sham yok)
   =/  shel=shell
-    [caller-1 fake-sig ~ id:triv-wheat 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:triv-wheat 1 333 town-id 0]
   =/  [res=state-transition rej=carton]
-    %^  ~(mill-all mil miller shard-id init-now)
+    %^  ~(mill-all mil miller town-id init-now)
     fake-land  (silt ~[[hash [shel yok]]])  1.024
   ;:  weld
   ::  assert that our call went through
@@ -1088,7 +1088,7 @@
     [`[%random-command ~] ~ ~]
   =/  hash=@ux  `@ux`(sham yok)
   =/  shel=shell
-    [caller-1 fake-sig ~ id:triv-wheat 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:triv-wheat 1 333 town-id 0]
   =/  bask=basket
     %-  silt
     %+  turn  (gulf 1 20)
@@ -1097,7 +1097,7 @@
     :_  yok
     shel(rate (sub 21 n), from [id:caller-1 n zigs:caller-1])
   =/  [res=state-transition rej=carton]
-    %^  ~(mill-all mil miller shard-id init-now)
+    %^  ~(mill-all mil miller town-id init-now)
     fake-land  bask  1.024
   =/  expected-cost
     ::  rates 20-1 all * 7
@@ -1128,7 +1128,7 @@
     [`[%random-command ~] ~ ~]
   =/  hash=@ux  `@ux`(sham yok)
   =/  shel=shell
-    [caller-1 fake-sig ~ id:triv-wheat 1 2.000 shard-id 0]
+    [caller-1 fake-sig ~ id:triv-wheat 1 2.000 town-id 0]
   =/  bask=basket
     %-  silt
     %+  turn  (gulf 1 100)
@@ -1137,7 +1137,7 @@
     :_  yok
     shel(rate (sub 101 n), from [id:caller-1 n zigs:caller-1])
   =/  [res=state-transition rej=carton]
-    %^  ~(mill-all mil miller shard-id init-now)
+    %^  ~(mill-all mil miller town-id init-now)
     fake-land  bask  1.024
   =/  expected-cost
     ::  rates 20-1 all * 7
@@ -1168,15 +1168,15 @@
     [`[%random-command ~] ~ ~]
   =/  hash-1=@ux  `@ux`(sham yok-1)
   =/  shel-1=shell
-    [caller-1 fake-sig ~ id:triv-wheat 1 333 shard-id 0]
+    [caller-1 fake-sig ~ id:triv-wheat 1 333 town-id 0]
   =/  yok-2=yolk
     [`[%random-command ~] ~ ~]
   =/  hash-2=@ux  `@ux`(sham yok-2)
   =/  shel-2=shell
-    [caller-2 fake-sig ~ id:triv-wheat 1 333 shard-id 0]
+    [caller-2 fake-sig ~ id:triv-wheat 1 333 town-id 0]
   ::
   =/  [res=state-transition rej=carton]
-    %^    ~(mill-all mil miller shard-id init-now)
+    %^    ~(mill-all mil miller town-id init-now)
         fake-land
       (silt ~[[hash-1 [shel-1 yok-1]] [hash-2 [shel-2 yok-2]]])
     1  ::  two calls must occur in parallel to work


### PR DESCRIPTION
I've been told that this naming convention is actually better, and agree --
`town`s are fundamentally different from shards, since shards are designed to serve the same logical "chain". Towns fit within the metaphor of rollup "cities", and indicate that these are actually separate areas of chain state that may be operating under different conditions (different standard library versions, possibly different execution engines).